### PR TITLE
Handled minDate and maxDate props for DatePicker component

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@
 Changelog available [here](https://github.com/dmtrKovalenko/material-ui-pickers/releases)
 
 ### Installation
-Available as npm package 
+Available as npm package
 ```sh
 npm install material-ui-pickers -S
 ```
 
-### Usage 
+### Usage
 Here is a quick example of how to use this package
 
 ```jsx
@@ -35,15 +35,15 @@ class App extends Component {
 
     return (
       <div>
-        <DatePicker 
+        <DatePicker
           value={selectedDate}
           onChange={this.handleDateChange}
-        />  
+        />
 
-        <TimePicker 
+        <TimePicker
           value={selectedTime}
           onChange={this.handleDateChange}
-        />  
+        />
       </div>
     )
   }
@@ -51,24 +51,26 @@ class App extends Component {
 ```
 
 ### Props documentation
-Here is a list of available props 
+Here is a list of available props
 
 #### Datepicker
 Prop | Type | Default | Definition
 ------------ | ------------- | ------------- | -------------
 value | string, number, Date object, Moment object | null | Datepicker value
 format | string | 'MMMM Do' | Moment format string for input
-autoOk | boolean | false | Auto accept date on selection 
+autoOk | boolean | false | Auto accept date on selection
 disableFuture | boolean | false | Disable future dates
 animateYearScrolling | boolean | false | Will animate year selection (note that will work for browser supports scrollIntoView api)
 openToYearSelection | boolean | false | Open datepicker from year selection
+minDate | string, number, Date object, Moment object | '1900-01-01' | Minimum selectable date
+maxDate | string, number, Date object, Moment object | '2100-01-01' | Maximum selectable date
 
 #### Timepicker
 Prop | Type | Default | Definition
 ------------ | ------------- | ------------- | -------------
 value | string, number, Date object, Moment object | null | Timepicker value
 format | string | 'MMMM Do' | Moment format string for input
-autoOk | boolean | false | Auto accept time on selection 
+autoOk | boolean | false | Auto accept time on selection
 
 ### Known Issues
 1. 24 hour displaying for timepicker (now supporting only am/pm)

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,9 +9,12 @@
     "react-scripts": "1.0.14"
   },
   "scripts": {
-    "start": "PORT=3002 react-scripts start",
+    "start": "cross-env PORT=3002 react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test --env=jsdom",
     "eject": "react-scripts eject"
+  },
+  "devDependencies": {
+    "cross-env": "^5.1.0"
   }
 }

--- a/src/DatePicker/Calendar.jsx
+++ b/src/DatePicker/Calendar.jsx
@@ -12,9 +12,16 @@ const moment = extendMoment(Moment);
 class Calendar extends PureComponent {
   static propTypes = {
     date: PropTypes.object.isRequired,
+    minDate: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.number]),
+    maxDate: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.number]),
     classes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
     disableFuture: PropTypes.bool.isRequired,
+  }
+
+  static defaultProps = {
+    minDate: '1900-01-01',
+    maxDate: '2100-01-01',
   }
 
   state = {
@@ -43,7 +50,7 @@ class Calendar extends PureComponent {
   }
 
   renderDays = (week) => {
-    const { disableFuture, classes, date } = this.props;
+    const { disableFuture, classes, date, minDate, maxDate } = this.props;
     const end = week.clone().endOf('week');
     const currentMonthNumber = this.state.currentMonth.get('month');
 
@@ -52,7 +59,7 @@ class Calendar extends PureComponent {
         const dayClass = classnames(classes.day, {
           [classes.hidden]: day.get('month') !== currentMonthNumber,
           [classes.selected]: day.toString() === date.toString(),
-          [classes.disabled]: disableFuture && day.isAfter(moment()),
+          [classes.disabled]: disableFuture && day.isAfter(moment()) || minDate && day.isBefore(minDate) || maxDate && day.isAfter(maxDate),
         });
 
         return (

--- a/src/DatePicker/DatePicker.jsx
+++ b/src/DatePicker/DatePicker.jsx
@@ -92,6 +92,8 @@ class DatePicker extends PureComponent {
                 date={this.date}
                 onChange={onChange}
                 disableFuture={disableFuture}
+                minDate={this.minDate}
+                maxDate={this.maxDate}
               />
         }
       </div>

--- a/src/DatePicker/DatePickerModal.jsx
+++ b/src/DatePicker/DatePickerModal.jsx
@@ -8,6 +8,8 @@ import DatePicker from './DatePicker';
 
 export default class DatePickerModal extends PureComponent {
   static propTypes = {
+    minDate: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.number]),
+    maxDate: PropTypes.oneOfType([PropTypes.object, PropTypes.string, PropTypes.number]),
     value: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     format: PropTypes.string,
     onChange: PropTypes.func.isRequired,
@@ -18,6 +20,8 @@ export default class DatePickerModal extends PureComponent {
   }
 
   static defaultProps = {
+    minDate: '1900-01-01',
+    maxDate: '2100-01-01',
     value: null,
     format: 'MMMM Do',
     autoOk: false,
@@ -59,7 +63,7 @@ export default class DatePickerModal extends PureComponent {
   render() {
     const { date } = this.state;
     const {
-      value, format, autoOk, onChange, disableFuture, animateYearScrolling, openToYearSelection,
+      value, format, autoOk, onChange, disableFuture, animateYearScrolling, openToYearSelection, minDate, maxDate,
       ...other
     } = this.props;
 
@@ -83,6 +87,8 @@ export default class DatePickerModal extends PureComponent {
             disableFuture={disableFuture}
             animateYearScrolling={animateYearScrolling}
             openToYearSelection={openToYearSelection}
+            minDate={minDate}
+            maxDate={maxDate}
           />
         </ModalDialog>
       </span>


### PR DESCRIPTION
I've seen that those props where present in DatePicker but not in DatePickerModal (which is exported), so I updated the Modal and Calendar components to handle them.