### PR TITLE
[Proposal] Move moment to peerDependencies

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "material-ui": "^1.0.0-beta.17",
+    "moment": "^2.19.1",
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "react-scripts": "1.0.14"

--- a/package.json
+++ b/package.json
@@ -34,10 +34,10 @@
     "react-dom": "^16.0.0",
     "prop-types": "^15.6.0",
     "material-ui": "^1.0.0-beta.17",
-    "classnames": "^2.2.5"
+    "classnames": "^2.2.5",
+    "moment": "^2.19.1"
   },
   "dependencies": {
-    "moment": "^2.19.1",
     "moment-range": "^3.0.3"
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -10,7 +10,7 @@ export default {
     { file: pkg.main, format: 'cjs' },
     { file: pkg.module, format: 'es' },
   ],
-  external: ['react', 'react-dom', 'prop-types', 'material-ui', 'classnames'],
+  external: ['react', 'react-dom', 'prop-types', 'material-ui', 'classnames', 'moment'],
   plugins: [
     resolve({
       extensions: ['.js', '.jsx'],


### PR DESCRIPTION
Hello again! Actually (as far I understand) it's impossible to set moment locale in a project that use this library and see the Datepicker localized because moment is bundled in `material-ui-pickers`. So I'm proposing to move `moment` to peerDependencies, so it will be possible to do this in the root of your project to localize all your Datepickers:

```javascript
import moment from 'moment';
import 'moment/locale/it';

moment.locale('it');
```