### PR TITLE
Update ModalDialog.jsx button alignment

### DIFF
--- a/src/_shared/ModalDialog.jsx
+++ b/src/_shared/ModalDialog.jsx
@@ -22,8 +22,8 @@ const ModalDialog = (props) => {
       </DialogContent>
 
       <DialogActions>
-        <Button color="primary" onClick={onAccept}> OK </Button>
         <Button color="primary" onClick={onDismiss}> Cancel </Button>
+        <Button color="primary" onClick={onAccept}> OK </Button>
       </DialogActions>
     </Dialog>
   );

--- a/src/_shared/ModalDialog.jsx
+++ b/src/_shared/ModalDialog.jsx
@@ -22,7 +22,7 @@ const ModalDialog = (props) => {
       </DialogContent>
 
       <DialogActions>
-        <Button color="primary" onClick={onDismiss}> Cancel </Button>
+        <Button color="primary" onClick={onDismiss} tabIndex={-1}> Cancel </Button>
         <Button color="primary" onClick={onAccept}> OK </Button>
       </DialogActions>
     </Dialog>


### PR DESCRIPTION
The 'OK' action button should be to the right of the 'Cancel' button. If we want the 'OK' to appear higher up in the HTML for tab reasons, I can update the CSS rules to align the buttons via styling

PR for #10 