### PR TITLE
Allow for changes in TextField to toggle Picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,16 @@ Available as npm package
 npm install material-ui-pickers -S
 ```
 
-We are using material-ui-icons font to display icons. We are working on additional way to pass icons,but for now its required. Just add this to your html 
+We are using material-ui-icons font to display icons.Just add this to your html 
 ```html
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 ```
-
+If you dont want to use icon font, or you are already use `material-ui-icons` you can pass any icon to the components with the following props 
+* leftArrowIcon - arrow left for datepicker
+* rightArrowIcon - arrow right for datepicker
+* dateRangeIcon - date tab icon for datetimepicker
+* timeIcon - time tab icon for datetimepicker
+ 
 ### Usage
 Here is a quick example of how to use this package
 

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ class App extends Component {
 
         <TimePicker
           value={selectedTime}
-          onChange={this.handleDateChange}
+          onChange={this.handleTimeChange}
         />
 
         <DateTimePicker
-          value={this.state.selectedDateTime}
+          value={selectedDateTime}
           onChange={this.handleDateTimeChange}
         />
       </div>

--- a/src/wrappers/ModalWrapper.jsx
+++ b/src/wrappers/ModalWrapper.jsx
@@ -57,6 +57,7 @@ export default class ModalWrapper extends PureComponent {
           value={value}
           format={format}
           onClick={this.togglePicker}
+          onFocus={this.togglePicker}
           invalidLabel={invalidLabel}
           {...other}
         />


### PR DESCRIPTION
Feedback from users of a tool I'm developing with material-ui-pickers is they wish they could trigger the date picker without having to click on it. Perhaps onFocus/onChange trigger could be better? I'm willing to discuss this in an issue. I didn't want to open an issue without a solution :)