### PR TITLE
Add `labelFunc` prop to DateTextField. This allows for custom message…

### DIFF
--- a/docs/src/Demo/Demo.jsx
+++ b/docs/src/Demo/Demo.jsx
@@ -14,11 +14,15 @@ class Demo extends Component {
   }
 
   state = {
-    selectedDate: new Date(),
+    selectedDate: moment(),
   }
 
   handleDateChange = date => {
     this.setState({ selectedDate: date })
+  }
+
+  handleWeekChange = date => {
+    this.setState({ selectedDate: date.clone().startOf('week') })
   }
 
   scrollToContent = () => {
@@ -31,6 +35,63 @@ class Demo extends Component {
 
   changeOutside = () => {
     this.setState({ selectedDate: moment('2015-02-02 12:44') })
+  }
+
+  renderWrappedDefaultDay = (date, selectedDate, dayInCurrentMonth) => {
+    const { classes } = this.props
+
+    const startDate = selectedDate.clone().day(0).startOf('day')
+    const endDate = selectedDate.clone().day(6).endOf('day')
+
+    const dayIsBetween = (
+      date.isSame(startDate) ||
+      date.isSame(endDate) ||
+      (date.isAfter(startDate) && date.isBefore(endDate))
+    )
+
+    const firstDay = date.isSame(startDate, 'day')
+    const lastDay = date.isSame(endDate, 'day')
+
+    const wrapperClassName = [
+      dayIsBetween ? classes.highlight : null,
+      firstDay ? classes.firstHighlight : null,
+      lastDay ? classes.endHighlight : null,
+    ].join(' ')
+
+    const dayClassName = [
+      classes.day,
+      (!dayInCurrentMonth) && classes.nonCurrentMonthDay,
+      (!dayInCurrentMonth && dayIsBetween) && classes.highlightNonCurrentMonthDay,
+    ].join(' ')
+
+    return (
+      <div className={wrapperClassName}>
+        <IconButton className={dayClassName}>
+          <span> { date.format('DD')} </span>
+        </IconButton>
+      </div>
+    )
+  }
+
+  formatWeekSelectLabel = (date, invalidLabel) => {
+    return date && date.isValid()
+      ? `Week of ${date.clone().startOf('week').format('MMM Do')}`
+      : invalidLabel
+  }
+
+  renderCustomDayForDateTime = (date, selectedDate, dayInCurrentMonth, dayComponent) => {
+    const { classes } = this.props
+
+    const dayClassName = [
+      (date.isSame(selectedDate, 'day')) && classes.customDayHighlight,
+    ].join(' ')
+
+    return (
+      <div className={classes.dayWrapper}>
+        {dayComponent}
+        <div className={dayClassName} />
+      </div>
+    )
   }
 
   render() {
@@ -157,6 +218,37 @@ class Demo extends Component {
               />
             </div>
           </div>
+
+          <Typography type="display1" gutterBottom>
+            Custom Day Element
+          </Typography>
+
+          <div className={classes.pickers}>
+            <div className="picker">
+              <Typography type="headline" align="center" gutterBottom>
+                Week picker
+              </Typography>
+
+              <DatePicker
+                value={this.state.selectedDate}
+                onChange={this.handleDateChange}
+                renderDay={this.renderWrappedDefaultDay}
+                labelFunc={this.formatWeekSelectLabel}
+              />
+            </div>
+
+            <div className="picker">
+              <Typography type="headline" align="center" gutterBottom>
+                DateTime picker
+              </Typography>
+
+              <DateTimePicker
+                value={this.state.selectedDate}
+                onChange={this.handleDateChange}
+                renderDay={this.renderCustomDayForDateTime}
+              />
+            </div>
+          </div>
         </div>
       </main>
     );
@@ -204,6 +296,44 @@ const styles = theme => ({
     paddingTop: 40,
     margin: '30px auto 50px',
     backgroundColor: theme.palette.background.default,
+  },
+  dayWrapper: {
+    position: 'relative',
+  },
+  day: {
+    width: 36,
+    height: 36,
+    fontSize: 14,
+    margin: '0 2px',
+    color: theme.palette.text.primary,
+  },
+  customDayHighlight: {
+    position: 'absolute',
+    top: 0,
+    bottom: 0,
+    left: '2px',
+    right: '2px',
+    border: '2px solid #6270bf',
+    borderRadius: '50%',
+  },
+  nonCurrentMonthDay: {
+    color: '#BCBCBC',
+  },
+  highlightNonCurrentMonthDay: {
+    color: '#676767',
+  },
+  highlight: {
+    background: '#9fa8da',
+  },
+  firstHighlight: {
+    extend: 'highlight',
+    borderTopLeftRadius: '50%',
+    borderBottomLeftRadius: '50%',
+  },
+  endHighlight: {
+    extend: 'highlight',
+    borderTopRightRadius: '50%',
+    borderBottomRightRadius: '50%',
   },
   content: {
     paddingTop: '60px',

--- a/src/DatePicker/Calendar.jsx
+++ b/src/DatePicker/Calendar.jsx
@@ -20,6 +20,7 @@ export class Calendar extends Component {
     disableFuture: PropTypes.bool,
     leftArrowIcon: PropTypes.string,
     rightArrowIcon: PropTypes.string,
+    renderDay: PropTypes.func,
   }
 
   static defaultProps = {
@@ -28,6 +29,7 @@ export class Calendar extends Component {
     disableFuture: false,
     leftArrowIcon: undefined,
     rightArrowIcon: undefined,
+    renderDay: undefined,
   }
 
   state = {
@@ -70,28 +72,42 @@ export class Calendar extends Component {
   }
 
   renderDays = (week) => {
-    const { classes, date } = this.props;
+    const { classes, date, renderDay } = this.props;
 
-    const selectedDate = date.clone().startOf('day').format();
+    const selectedDate = date.clone().startOf('day');
+    const formattedSelectedDate = selectedDate.format();
     const end = week.clone().endOf('week');
     const currentMonthNumber = this.state.currentMonth.get('month');
 
     return Array.from(moment.range(week, end).by('day'))
       .map((day) => {
+        const dayInCurrentMonth = day.get('month') === currentMonthNumber;
+
         const dayClass = classnames(classes.day, {
-          [classes.hidden]: day.get('month') !== currentMonthNumber,
-          [classes.selected]: day.format() === selectedDate,
+          [classes.hidden]: !dayInCurrentMonth,
+          [classes.selected]: day.format() === formattedSelectedDate,
           [classes.disabled]: this.shouldDisableDate(day),
         });
 
-        return (
-          <IconButton
-            key={day.toString()}
-            className={dayClass}
-            onClick={() => this.onDateSelect(day)}
-          >
+        let dayComponent = (
+          <IconButton className={dayClass}>
             <span> { day.format('DD')} </span>
           </IconButton>
+        );
+
+        if (renderDay) {
+          dayComponent = renderDay(day, selectedDate, dayInCurrentMonth, dayComponent);
+        }
+
+        return (
+          <div
+            key={day.toString()}
+            onClick={() => dayInCurrentMonth && this.onDateSelect(day)}
+            onKeyPress={() => dayInCurrentMonth && this.onDateSelect(day)}
+            role="presentation"
+          >
+            {dayComponent}
+          </div>
         );
       });
   }

--- a/src/DatePicker/DatePicker.jsx
+++ b/src/DatePicker/DatePicker.jsx
@@ -22,6 +22,7 @@ export class DatePicker extends PureComponent {
     children: PropTypes.node,
     leftArrowIcon: PropTypes.string,
     rightArrowIcon: PropTypes.string,
+    renderDay: PropTypes.func,
   }
 
   static defaultProps = {
@@ -33,6 +34,7 @@ export class DatePicker extends PureComponent {
     children: null,
     leftArrowIcon: undefined,
     rightArrowIcon: undefined,
+    renderDay: undefined,
   }
 
   state = {
@@ -73,6 +75,7 @@ export class DatePicker extends PureComponent {
       animateYearScrolling,
       leftArrowIcon,
       rightArrowIcon,
+      renderDay,
     } = this.props;
     const { showYearSelection } = this.state;
 
@@ -116,6 +119,7 @@ export class DatePicker extends PureComponent {
                 maxDate={this.maxDate}
                 leftArrowIcon={leftArrowIcon}
                 rightArrowIcon={rightArrowIcon}
+                renderDay={renderDay}
               />
         }
       </div>

--- a/src/DatePicker/DatePickerWrapper.jsx
+++ b/src/DatePicker/DatePickerWrapper.jsx
@@ -21,6 +21,8 @@ export default class DatePickerWrapper extends PickerBase {
     invalidLabel: PropTypes.string,
     leftArrowIcon: PropTypes.string,
     rightArrowIcon: PropTypes.string,
+    renderDay: PropTypes.func,
+    labelFunc: PropTypes.func,
   }
 
   static defaultProps = {
@@ -36,6 +38,8 @@ export default class DatePickerWrapper extends PickerBase {
     invalidLabel: undefined,
     leftArrowIcon: undefined,
     rightArrowIcon: undefined,
+    renderDay: undefined,
+    labelFunc: undefined,
   }
 
   render() {
@@ -54,6 +58,8 @@ export default class DatePickerWrapper extends PickerBase {
       invalidLabel,
       leftArrowIcon,
       rightArrowIcon,
+      renderDay,
+      labelFunc,
       ...other
     } = this.props;
 
@@ -65,6 +71,7 @@ export default class DatePickerWrapper extends PickerBase {
         onAccept={this.handleAccept}
         onDismiss={this.handleDismiss}
         invalidLabel={invalidLabel}
+        labelFunc={labelFunc}
         {...other}
       >
         <DatePicker
@@ -77,6 +84,7 @@ export default class DatePickerWrapper extends PickerBase {
           maxDate={maxDate}
           leftArrowIcon={leftArrowIcon}
           rightArrowIcon={rightArrowIcon}
+          renderDay={renderDay}
         />
       </ModalWrapper>
     );

--- a/src/DateTimePicker/DateTimePicker.jsx
+++ b/src/DateTimePicker/DateTimePicker.jsx
@@ -28,6 +28,7 @@ export class DateTimePicker extends Component {
     rightArrowIcon: PropTypes.string,
     dateRangeIcon: PropTypes.string,
     timeIcon: PropTypes.string,
+    renderDay: PropTypes.func,
   }
 
   static defaultProps = {
@@ -41,6 +42,7 @@ export class DateTimePicker extends Component {
     rightArrowIcon: undefined,
     dateRangeIcon: undefined,
     timeIcon: undefined,
+    renderDay: undefined,
   }
 
   state = {
@@ -84,6 +86,7 @@ export class DateTimePicker extends Component {
       rightArrowIcon,
       dateRangeIcon,
       timeIcon,
+      renderDay,
     } = this.props;
 
     return (
@@ -125,6 +128,7 @@ export class DateTimePicker extends Component {
             disableFuture={disableFuture}
             leftArrowIcon={leftArrowIcon}
             rightArrowIcon={rightArrowIcon}
+            renderDay={renderDay}
           />
         </View>
 

--- a/src/DateTimePicker/DateTimePickerWrapper.jsx
+++ b/src/DateTimePicker/DateTimePickerWrapper.jsx
@@ -28,6 +28,8 @@ export class DateTimePickerWrapper extends PickerBase {
     rightArrowIcon: PropTypes.string,
     dateRangeIcon: PropTypes.string,
     timeIcon: PropTypes.string,
+    renderDay: PropTypes.func,
+    labelFunc: PropTypes.func,
   }
 
   static defaultProps = {
@@ -46,6 +48,8 @@ export class DateTimePickerWrapper extends PickerBase {
     rightArrowIcon: undefined,
     dateRangeIcon: undefined,
     timeIcon: undefined,
+    renderDay: undefined,
+    labelFunc: undefined,
   }
 
   render() {
@@ -67,6 +71,8 @@ export class DateTimePickerWrapper extends PickerBase {
       rightArrowIcon,
       dateRangeIcon,
       timeIcon,
+      renderDay,
+      labelFunc,
       ...other
     } = this.props;
 
@@ -81,6 +87,7 @@ export class DateTimePickerWrapper extends PickerBase {
         onDismiss={this.handleDismiss}
         dialogContentClassName={dialogClassName}
         invalidLabel={invalidLabel}
+        labelFunc={labelFunc}
         {...other}
       >
         <DateTimePicker
@@ -96,6 +103,7 @@ export class DateTimePickerWrapper extends PickerBase {
           rightArrowIcon={rightArrowIcon}
           dateRangeIcon={dateRangeIcon}
           timeIcon={timeIcon}
+          renderDay={renderDay}
         />
       </ModalWrapper>
     );

--- a/src/_shared/DateTextField.jsx
+++ b/src/_shared/DateTextField.jsx
@@ -15,12 +15,14 @@ export default class DateTextField extends Component {
     format: PropTypes.string.isRequired,
     onClick: PropTypes.func.isRequired,
     invalidLabel: PropTypes.string,
+    labelFunc: PropTypes.func,
   }
 
   static defaultProps = {
     disabled: false,
     invalidLabel: 'Unknown',
     value: new Date(),
+    labelFunc: undefined,
   }
 
   shouldComponentUpdate = nextProps => (
@@ -29,8 +31,18 @@ export default class DateTextField extends Component {
   )
 
   getDisplayDate = () => {
-    const { value, format, invalidLabel } = this.props;
+    const {
+      value,
+      format,
+      invalidLabel,
+      labelFunc,
+    } = this.props;
+
     const date = moment(value);
+
+    if (labelFunc) {
+      return labelFunc(date, invalidLabel);
+    }
 
     return date.isValid()
       ? date.format(format)
@@ -58,7 +70,7 @@ export default class DateTextField extends Component {
 
   render() {
     const {
-      value, format, disabled, onClick, invalidLabel, ...other
+      value, format, disabled, onClick, invalidLabel, labelFunc, ...other
     } = this.props;
 
     return (

--- a/src/wrappers/ModalWrapper.jsx
+++ b/src/wrappers/ModalWrapper.jsx
@@ -13,12 +13,14 @@ export default class ModalWrapper extends PureComponent {
     onDismiss: PropTypes.func.isRequired,
     dialogContentClassName: PropTypes.string,
     invalidLabel: PropTypes.string,
+    labelFunc: PropTypes.func,
   }
 
   static defaultProps = {
     dialogContentClassName: '',
     invalidLabel: undefined,
     value: new Date(),
+    labelFunc: undefined,
   }
 
   state = {
@@ -48,6 +50,7 @@ export default class ModalWrapper extends PureComponent {
       onAccept,
       onDismiss,
       invalidLabel,
+      labelFunc,
       ...other
     } = this.props;
 
@@ -58,6 +61,7 @@ export default class ModalWrapper extends PureComponent {
           format={format}
           onClick={this.togglePicker}
           invalidLabel={invalidLabel}
+          labelFunc={labelFunc}
           {...other}
         />
 


### PR DESCRIPTION
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->
#36 

## Description

- Add `labelFunc` prop to DateTextField. This allows for custom messages to be rendered in the TextField. This is helpful when the picker may no longer affect only one date (see week picker added to the demos) and when users need more flexibility.
- Add `renderDay` prop to Calendar. This allows a user to override how each day is rendered in the calendar.
`renderDay(date: moment, selectedDate: moment, dayInCurrentMonth: bool, dayComponent: ReactElement)`
- Add a wrapper div around each rendered day. This allows the Calendar to set the element key and listen for click events without exposing that interest when using the `renderDay` hook
- Add support for these two props to DatePicker and DateTimePicker
- Add examples using the two props to the demos page

