### PR TITLE
make onAccept and onDismiss optional when using ts

### DIFF
--- a/lib/src/wrappers/ModalWrapper.d.ts
+++ b/lib/src/wrappers/ModalWrapper.d.ts
@@ -5,8 +5,8 @@ import { Utils } from '../utils/utils';
 import {DateTextFieldProps} from '../_shared/DateTextField';
 
 export interface ModalWrapperProps extends DateTextFieldProps {
-    onAccept: ButtonProps['onClick'];
-    onDismiss: ButtonProps['onClick'];
+    onAccept?: ButtonProps['onClick'];
+    onDismiss?: ButtonProps['onClick'];
     dialogContentClassName?: string;
     okLabel?: ReactNode;
     cancelLabel?: ReactNode;

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -27,7 +27,7 @@ export default class ModalWrapper extends PureComponent {
     cancelLabel: undefined,
     format: undefined,
     onAccept: undefined,
-    onDismiss: undefined
+    onDismiss: undefined,
   }
 
   state = {
@@ -41,14 +41,14 @@ export default class ModalWrapper extends PureComponent {
   handleAccept = () => {
     this.togglePicker(); // close
     if (this.props.onAccept) {
-        this.props.onAccept();
+      this.props.onAccept();
     }
   }
 
   handleDismiss = () => {
     this.togglePicker();
     if (this.props.onDismiss) {
-        this.props.onDismiss();
+      this.props.onDismiss();
     }
   }
 

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -9,8 +9,8 @@ export default class ModalWrapper extends PureComponent {
     value: DomainPropTypes.date,
     children: PropTypes.node.isRequired,
     format: PropTypes.string,
-    onAccept: PropTypes.func.isRequired,
-    onDismiss: PropTypes.func.isRequired,
+    onAccept: PropTypes.func,
+    onDismiss: PropTypes.func,
     dialogContentClassName: PropTypes.string,
     invalidLabel: PropTypes.string,
     labelFunc: PropTypes.func,
@@ -38,12 +38,12 @@ export default class ModalWrapper extends PureComponent {
 
   handleAccept = () => {
     this.togglePicker(); // close
-    this.props.onAccept();
+    this.props.onAccept && this.props.onAccept();
   }
 
   handleDismiss = () => {
     this.togglePicker();
-    this.props.onDismiss();
+    this.props.onDismiss && this.props.onDismiss();
   }
 
   render() {

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -26,6 +26,8 @@ export default class ModalWrapper extends PureComponent {
     okLabel: undefined,
     cancelLabel: undefined,
     format: undefined,
+    onAccept: undefined,
+    onDismiss: undefined
   }
 
   state = {
@@ -38,12 +40,16 @@ export default class ModalWrapper extends PureComponent {
 
   handleAccept = () => {
     this.togglePicker(); // close
-    this.props.onAccept && this.props.onAccept();
+    if (this.props.onAccept) {
+        this.props.onAccept();
+    }
   }
 
   handleDismiss = () => {
     this.togglePicker();
-    this.props.onDismiss && this.props.onDismiss();
+    if (this.props.onDismiss) {
+        this.props.onDismiss();
+    }
   }
 
   render() {


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description

when i use material-ui-picker in a tsx like below:

```typescript
import { DatePicker } from 'material-ui-pickers/src';

...

<DatePicker
  value={this.state.selectedDate}
  onChange={this.handleDateChange}
/>

...
```

the compiler would throw an error and told me `onAccept` and `onDismiss` is required, however if i add `onAccept` and `onDismiss` like below:

```typescript
...

handleDateAccept = (event: React.MouseEvent<HTMLElement>): void => undefined;
handleDateDismiss = (event: React.MouseEvent<HTMLElement>): void => undefined;

...

<DatePicker
  value={this.state.selectedDate}
  onChange={this.handleDateChange}
  onAccept={handleDateAccept}
  onDismiss={handleDateDismiss}
/>

...
```

then `onChange` method won't work after I pick a new date, so i checkout the `ModalWrapper.d.ts `, so modified the interface...