### PR TITLE
Fix some issues with keyboard mode

### DIFF
--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -93,7 +93,7 @@ export default class DatePickerWrapper extends PickerBase {
         value={value}
         format={format}
         onAccept={this.handleAccept}
-        onChange={this.handleChange}
+        onChange={this.handleTextFieldChange}
         onDismiss={this.handleDismiss}
         invalidLabel={invalidLabel}
         labelFunc={labelFunc}

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
@@ -97,7 +97,7 @@ export class DateTimePickerWrapper extends PickerBase {
         value={value}
         format={this.getFormat()}
         onAccept={this.handleAccept}
-        onChange={this.handleChange}
+        onChange={this.handleTextFieldChange}
         onDismiss={this.handleDismiss}
         dialogContentClassName={dialogClassName}
         invalidLabel={invalidLabel}

--- a/lib/src/TimePicker/TimePickerWrapper.jsx
+++ b/lib/src/TimePicker/TimePickerWrapper.jsx
@@ -49,7 +49,7 @@ export default class TimePickerWrapper extends PickerBase {
         value={value}
         format={this.getFormat()}
         onAccept={this.handleAccept}
-        onChange={this.handleChange}
+        onChange={this.handleTextFieldChange}
         onDismiss={this.handleDismiss}
         invalidLabel={invalidLabel}
         {...other}

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -91,13 +91,19 @@ export default class DateTextField extends PureComponent {
   handleFocus = (e) => {
     e.stopPropagation();
     e.preventDefault();
-    const { disabled, onClick, keyboard } = this.props;
+    const { keyboard } = this.props;
 
-    if (keyboard && e.target.tagName.toLowerCase() !== 'span') {
+    if (keyboard) {
       return;
     }
 
     e.target.blur();
+
+    this.openPicker(e);
+  }
+
+  openPicker = (e) => {
+    const { disabled, onClick } = this.props;
 
     if (!disabled) {
       onClick(e);
@@ -106,39 +112,38 @@ export default class DateTextField extends PureComponent {
 
   render() {
     const {
-      format, disabled, onClick, invalidLabel, labelFunc, keyboard, value, mask, ...other
+      format, disabled, onClick, invalidLabel, labelFunc, keyboard, value, mask, InputProps,
+      ...other
     } = this.props;
     const { displayValue, error } = this.state;
 
+    const localInputProps = {
+      inputComponent: MaskedInput,
+      inputProps: { mask },
+    };
+
+    if (keyboard) {
+      localInputProps.endAdornment = (
+        <InputAdornment position="end">
+          <IconButton onClick={this.openPicker}>event</IconButton>
+        </InputAdornment>
+      );
+    }
+
     return (
-      <div>
-        <TextField
-          readOnly
-          onClick={this.handleFocus}
-          error={!!error}
-          helperText={error}
-          onKeyPress={this.handleChange}
-          onBlur={e => e.preventDefault() && e.stopPropagation()}
-          disabled={disabled}
-          value={displayValue}
-          {...other}
-          onChange={this.handleChange}
-          inputProps={{
-            mask,
-          }}
-          InputProps={keyboard ? {
-            endAdornment: (
-              <InputAdornment
-                onClick={this.handleFocus}
-                position="end"
-              >
-                <IconButton>  event  </IconButton>
-              </InputAdornment>
-            ),
-            inputComponent: MaskedInput,
-          } : this.props.InputProps}
-        />
-      </div>
+      <TextField
+        readOnly
+        onClick={this.handleFocus}
+        error={!!error}
+        helperText={error}
+        onKeyPress={this.handleChange}
+        onBlur={e => e.preventDefault() && e.stopPropagation()}
+        disabled={disabled}
+        value={displayValue}
+        {...other}
+        onChange={this.handleChange}
+        InputProps={{ ...localInputProps, ...InputProps }}
+      />
     );
   }
 }

--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -13,7 +13,6 @@ export default class PickerBase extends PureComponent {
     format: PropTypes.string,
     labelFunc: PropTypes.func,
     ampm: PropTypes.bool,
-    keyboard: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -23,7 +22,6 @@ export default class PickerBase extends PureComponent {
     labelFunc: undefined,
     format: undefined,
     ampm: true,
-    keyboard: false,
   }
 
   getValidDateOrCurrent = (props = this.props) => {
@@ -70,13 +68,14 @@ export default class PickerBase extends PureComponent {
 
   handleChange = (date, isFinish = true) => {
     this.setState({ date }, () => {
-      if (isFinish && (this.props.autoOk || this.props.keyboard)) {
-        this.handleAccept();
-      }
-
       if (isFinish && this.props.autoOk) {
+        this.handleAccept();
         this.togglePicker();
       }
     });
+  }
+
+  handleTextFieldChange = (date) => {
+    this.setState({ date }, this.handleAccept);
   }
 }


### PR DESCRIPTION
## Description
Fix some issues with the keyboard mode

- make masked input compatible with material-ui ^1.0.0-beta.23
- picker can be opened in Firefox
- only change the value when accepting when using the picker with keyboard enabled

I removed the wrapping div in the DateTextField Component. If it has any purpose I can revert that change.

