### PR TITLE
Fix Clock on touch devices

### DIFF
--- a/lib/src/TimePicker/Clock.jsx
+++ b/lib/src/TimePicker/Clock.jsx
@@ -38,16 +38,20 @@ export class Clock extends Component {
   }
 
   handleTouchMove = (e) => {
+    this.isMoving = true;
     this.setTime(e);
   }
 
-  handleTouchEnd = (e) => {
-    this.setTime(e, true);
+  handleClick = (e) => {
+    this.setTime(e.nativeEvent, true);
   }
 
-  handleUp = (event) => {
-    event.preventDefault();
-    this.setTime(event.nativeEvent, true);
+  handleUp = (e) => {
+    if (this.isMoving) {
+      e.preventDefault();
+      this.setTime(e.nativeEvent, true);
+      this.isMoving = false;
+    }
   };
 
   handleMove = (e) => {
@@ -90,8 +94,9 @@ export class Clock extends Component {
             role="menu"
             tabIndex={-1}
             className={classes.squareMask}
+            onClick={this.handleClick}
             onTouchMove={this.handleTouchMove}
-            onTouchEnd={this.handleTouchEnd}
+            onTouchEnd={this.handleUp}
             onMouseUp={this.handleUp}
             onMouseMove={this.handleMove}
           />

--- a/lib/src/TimePicker/Clock.jsx
+++ b/lib/src/TimePicker/Clock.jsx
@@ -42,10 +42,6 @@ export class Clock extends Component {
     this.setTime(e);
   }
 
-  handleClick = (e) => {
-    this.setTime(e.nativeEvent, true);
-  }
-
   handleMouseUp = (e) => {
     if (this.isMoving) {
       this.isMoving = false;

--- a/lib/src/TimePicker/Clock.jsx
+++ b/lib/src/TimePicker/Clock.jsx
@@ -46,13 +46,19 @@ export class Clock extends Component {
     this.setTime(e.nativeEvent, true);
   }
 
-  handleUp = (e) => {
+  handleMouseUp = (e) => {
     if (this.isMoving) {
-      e.preventDefault();
+      this.isMoving = false;
+    }
+    this.setTime(e.nativeEvent, true);
+  }
+
+  handleTouchEnd = (e) => {
+    if (this.isMoving) {
       this.setTime(e.nativeEvent, true);
       this.isMoving = false;
     }
-  };
+  }
 
   handleMove = (e) => {
     e.preventDefault();
@@ -94,10 +100,9 @@ export class Clock extends Component {
             role="menu"
             tabIndex={-1}
             className={classes.squareMask}
-            onClick={this.handleClick}
             onTouchMove={this.handleTouchMove}
-            onTouchEnd={this.handleUp}
-            onMouseUp={this.handleUp}
+            onTouchEnd={this.handleTouchEnd}
+            onMouseUp={this.handleMouseUp}
             onMouseMove={this.handleMove}
           />
 


### PR DESCRIPTION
Fixes #111

Handle `touchend` and `mouseup` only if there was `touchmove` or `mousemove` first to avoid handling both `touchend` and `mousemove` on touch devices

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch: