### PR TITLE
Material ui beta24 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ class App extends Component {
 ### Props documentation
 Here is a list of available props
 
+**Note:** Any prop not recognized by the pickers and their sub-components are passed down to material-ui [TextField](https://material-ui-next.com/api/text-field/#props) component.
+
 #### Datepicker
 * date - string, number, Date object, Moment object ([anything](https://momentjs.com/docs/#/parsing/), that can be parsed by moment)
 
@@ -94,6 +96,8 @@ maxDate | date | '2100-01-01' | Maximum selectable date
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
+okLabel | string | 'OK' | The label for the ok button
+cancelLabel | string | 'CANCEL' | The label for the cancel button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
 leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
@@ -111,6 +115,8 @@ autoOk | boolean | false | Auto accept time on selection
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
+okLabel | string | 'OK' | The label for the ok button
+cancelLabel | string | 'CANCEL' | The label for the cancel button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
 ampm | boolean | true | 12h/24h view for hour selection clock
 keyboard | boolean | false | Allow to manual input date to the text field
@@ -131,6 +137,8 @@ maxDate | date | '2100-01-01' | Maximum selectable date
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChangeg
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
+okLabel | string | 'OK' | The label for the ok button
+cancelLabel | string | 'CANCEL' | The label for the cancel button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
 leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
@@ -153,7 +161,14 @@ moment.locale('fr')
 
 ### Jalali Calendar
 We are fully supporting Jalali calendar system and [right-to-left](https://material-ui-next.com/guides/right-to-left/) material-ui api. Special thanks to @alitaheri.
-Here is a little example of how to use it 
+Here is a little example of how to use it
+
+Don't forget to install [material-ui-pickers-jalali-utils](https://github.com/alitaheri/material-ui-pickers-jalali-utils).
+
+```sh
+npm install material-ui-pickers-jalali-utils
+```
+
 ```jsx
 import { TimePicker, DateTimePicker, DatePicker } from 'material-ui-pickers';
 import jalaliUtils from 'material-ui-pickers-jalali-utils';

--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,7 @@
     "jss": "^9.3.3",
     "jss-preset-default": "^4.0.1",
     "jss-rtl": "^0.2.1",
-    "material-ui": "^1.0.0-beta.22",
+    "material-ui": "^1.0.0-beta.24",
     "material-ui-pickers-jalali-utils": "^0.2.0",
     "moment": "^2.19.3",
     "moment-jalaali": "^0.7.2",

--- a/docs/src/Demo/Demo.jsx
+++ b/docs/src/Demo/Demo.jsx
@@ -61,7 +61,7 @@ class Demo extends Component {
 
             <a href="https://github.com/dmtrKovalenko/material-ui-pickers">
               <IconButton>
-                <Github color="white" />
+                <Github color="contrast" />
               </IconButton>
             </a>
           </Toolbar>

--- a/lib/package.json
+++ b/lib/package.json
@@ -34,7 +34,7 @@
     "react": "^16.0.0",
     "react-dom": "^16.0.0",
     "prop-types": "^15.6.0",
-    "material-ui": "^1.0.0-beta.18",
+    "material-ui": "^1.0.0-beta.24",
     "classnames": "^2.2.5",
     "moment": "^2.19.2"
   },
@@ -79,7 +79,7 @@
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
     "jest": "^21.2.1",
-    "material-ui": "^1.0.0-beta.21",
+    "material-ui": "^1.0.0-beta.24",
     "moment": "^2.19.2",
     "peer-deps-externals-webpack-plugin": "^1.0.2",
     "prop-types": "^15.6.0",

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -28,7 +28,7 @@ const ModalDialog = ({
   dialogContentClassName,
   ...other
 }) => (
-  <Dialog onRequestClose={onDismiss} classes={{ paper: classes.dialogRoot }} {...other}>
+  <Dialog onClose={onDismiss} classes={{ paper: classes.dialogRoot }} {...other}>
     <DialogContent className={classnames(classes.dialog, dialogContentClassName)}>
       { children }
     </DialogContent>

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -34,19 +34,19 @@ export default class ModalWrapper extends PureComponent {
     open: false,
   }
 
-  togglePicker = () => {
-    this.setState({ open: !this.state.open });
+  handleClick = () => {
+    this.setState({ open: true });
   }
 
   handleAccept = () => {
-    this.togglePicker(); // close
+    this.setState({ open: false });
     if (this.props.onAccept) {
       this.props.onAccept();
     }
   }
 
   handleDismiss = () => {
-    this.togglePicker();
+    this.setState({ open: false });
     if (this.props.onDismiss) {
       this.props.onDismiss();
     }
@@ -72,7 +72,7 @@ export default class ModalWrapper extends PureComponent {
         <DateTextField
           value={value}
           format={format}
-          onClick={this.togglePicker}
+          onClick={this.handleClick}
           // onFocus={this.togglePicker} <- Currently not properly works with .blur() on TextField
           invalidLabel={invalidLabel}
           labelFunc={labelFunc}
@@ -87,7 +87,7 @@ export default class ModalWrapper extends PureComponent {
           okLabel={okLabel}
           cancelLabel={cancelLabel}
         >
-          { children }
+          {children}
         </ModalDialog>
       </div>
     );


### PR DESCRIPTION
* Adds [material-ui@1.0.0-beta-24](https://github.com/mui-org/material-ui/releases/tag/v1.0.0-beta.24) support.
* Slightly improves documentation, Fixes #106
* Fixes #98

It also sets the minimum required material-ui version to `1.0.0-beta.24` due to the breaking change introduced by [material-ui@9451](https://github.com/mui-org/material-ui/pull/9451)