### PR TITLE
add disablePast option

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ value | date | new Date() | Timepicker value
 format | string | 'MMMM Do hh:mm a' | Moment format string for input
 autoOk | boolean | false | Auto accept time on selection
 autoSubmit | boolean | true | On change show next time input (year -> date -> hour -> minute)
+disablePast | boolean | false | Disable past dates
+disableFuture | boolean | false | Disable future dates
 showTabs | boolean | false | Show date/time tabs
 openTo | one of 'year', 'date', 'hour', 'minutes' | 'date' | Open to particular view
 animateYearScrolling | boolean | false | Will animate year selection

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Prop | Type | Default | Definition
 value | date | new Date() | Datepicker value
 format | string | 'MMMM Do' | Moment format string for input
 autoOk | boolean | false | Auto accept date on selection
+disablePast | boolean | false | Disable past dates
 disableFuture | boolean | false | Disable future dates
 animateYearScrolling | boolean | false | Will animate year selection (note that will work for browser supports scrollIntoView api)
 openToYearSelection | boolean | false | Open datepicker from year selection

--- a/lib/src/DatePicker/Calendar.d.ts
+++ b/lib/src/DatePicker/Calendar.d.ts
@@ -20,6 +20,7 @@ export interface CalendarProps {
     minDate?: DateType;
     maxDate?: DateType;
     onChange: (date: object) => void;
+    disablePast?: boolean;
     disableFuture?: boolean;
     leftArrowIcon?: ReactNode;
     rightArrowIcon?: ReactNode;

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -18,6 +18,7 @@ export class Calendar extends Component {
     maxDate: DomainPropTypes.date,
     classes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
+    disablePast: PropTypes.bool,
     disableFuture: PropTypes.bool,
     leftArrowIcon: PropTypes.node,
     rightArrowIcon: PropTypes.node,
@@ -29,6 +30,7 @@ export class Calendar extends Component {
   static defaultProps = {
     minDate: '1900-01-01',
     maxDate: '2100-01-01',
+    disablePast: false,
     disableFuture: false,
     leftArrowIcon: undefined,
     rightArrowIcon: undefined,
@@ -65,9 +67,11 @@ export class Calendar extends Component {
   }
 
   shouldDisableDate = (day) => {
-    const { disableFuture, shouldDisableDate } = this.props;
+    const { disablePast, disableFuture, shouldDisableDate } = this.props;
     return (
-      (disableFuture && day.isAfter(moment())) || this.validateMinMaxDate(day) ||
+      (disableFuture && day.isAfter(moment(), 'day')) ||
+      (disablePast && day.isBefore(moment(), 'day')) ||
+      this.validateMinMaxDate(day) ||
       shouldDisableDate(day)
     );
   }

--- a/lib/src/DatePicker/DatePicker.d.ts
+++ b/lib/src/DatePicker/DatePicker.d.ts
@@ -9,6 +9,7 @@ export interface DatePickerProps {
     minDate?: DateType;
     maxDate?: DateType;
     onChange: (date: object, isFinished?: boolean) => void;
+    disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;
     openToYearSelection?: boolean;

--- a/lib/src/DatePicker/DatePicker.jsx
+++ b/lib/src/DatePicker/DatePicker.jsx
@@ -17,6 +17,7 @@ export class DatePicker extends PureComponent {
     maxDate: DomainPropTypes.date,
     classes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
+    disablePast: PropTypes.bool,
     disableFuture: PropTypes.bool,
     animateYearScrolling: PropTypes.bool,
     openToYearSelection: PropTypes.bool,
@@ -31,6 +32,7 @@ export class DatePicker extends PureComponent {
   static defaultProps = {
     minDate: '1900-01-01',
     maxDate: '2100-01-01',
+    disablePast: false,
     disableFuture: false,
     animateYearScrolling: undefined,
     openToYearSelection: false,
@@ -75,6 +77,7 @@ export class DatePicker extends PureComponent {
   render() {
     const {
       classes,
+      disablePast,
       disableFuture,
       onChange,
       animateYearScrolling,
@@ -114,6 +117,7 @@ export class DatePicker extends PureComponent {
                 onChange={this.handleYearSelect}
                 minDate={this.minDate}
                 maxDate={this.maxDate}
+                disablePast={disablePast}
                 disableFuture={disableFuture}
                 animateYearScrolling={animateYearScrolling}
                 utils={utils}
@@ -122,6 +126,7 @@ export class DatePicker extends PureComponent {
               <Calendar
                 date={this.date}
                 onChange={onChange}
+                disablePast={disablePast}
                 disableFuture={disableFuture}
                 minDate={this.minDate}
                 maxDate={this.maxDate}

--- a/lib/src/DatePicker/DatePickerWrapper.d.ts
+++ b/lib/src/DatePicker/DatePickerWrapper.d.ts
@@ -10,6 +10,7 @@ export interface DatePickerWrapperProps extends ModalWrapperProps {
     maxDate?: DateType;
     onChange: (date: object) => void;
     autoOk?: boolean;
+    disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;
     openToYearSelection?: boolean;

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -21,6 +21,8 @@ export default class DatePickerWrapper extends PickerBase {
     onChange: PropTypes.func.isRequired,
     /* Auto accept date on selection */
     autoOk: PropTypes.bool,
+    /* Disable past dates */
+    disablePast: PropTypes.bool,
     /* Disable future dates */
     disableFuture: PropTypes.bool,
     /* To animate scrolling to current year (with scrollIntoView) */
@@ -52,6 +54,7 @@ export default class DatePickerWrapper extends PickerBase {
     returnMoment: true,
     minDate: undefined,
     maxDate: undefined,
+    disablePast: undefined,
     disableFuture: undefined,
     animateYearScrolling: undefined,
     openToYearSelection: undefined,
@@ -73,6 +76,7 @@ export default class DatePickerWrapper extends PickerBase {
       minDate,
       maxDate,
       onChange,
+      disablePast,
       disableFuture,
       animateYearScrolling,
       openToYearSelection,
@@ -102,6 +106,7 @@ export default class DatePickerWrapper extends PickerBase {
         <DatePicker
           date={date}
           onChange={this.handleChange}
+          disablePast={disablePast}
           disableFuture={disableFuture}
           animateYearScrolling={animateYearScrolling}
           openToYearSelection={openToYearSelection}

--- a/lib/src/DatePicker/YearSelection.d.ts
+++ b/lib/src/DatePicker/YearSelection.d.ts
@@ -7,6 +7,7 @@ export interface YearSelectionProps {
     minDate?: DateType;
     maxDate?: DateType;
     onChange: (date: object) => void;
+    disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;
     utils?: Utils;

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -16,6 +16,7 @@ export class YearSelection extends PureComponent {
     maxDate: DomainPropTypes.date.isRequired,
     classes: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
+    disablePast: PropTypes.bool.isRequired,
     disableFuture: PropTypes.bool.isRequired,
     animateYearScrolling: PropTypes.bool,
     utils: PropTypes.object,
@@ -50,7 +51,7 @@ export class YearSelection extends PureComponent {
 
   render() {
     const {
-      minDate, maxDate, date, classes, disableFuture, utils,
+      minDate, maxDate, date, classes, disablePast, disableFuture, utils,
     } = this.props;
     const currentYear = utils.getYear(date);
 
@@ -62,7 +63,10 @@ export class YearSelection extends PureComponent {
               const yearNumber = utils.getYear(year);
               const className = classnames(classes.yearItem, {
                 [classes.selectedYear]: yearNumber === currentYear,
-                [classes.disabled]: disableFuture && year.isAfter(moment()),
+                [classes.disabled]: (
+                  (disablePast && year.isBefore(moment(), 'year')) ||
+                  (disableFuture && year.isAfter(moment(), 'year'))
+                ),
               });
 
               return (

--- a/lib/src/DateTimePicker/DateTimePicker.d.ts
+++ b/lib/src/DateTimePicker/DateTimePicker.d.ts
@@ -10,6 +10,7 @@ export interface DateTimePickerProps {
   minDate?: DateType;
   maxDate?: DateType;
   onChange: (date: object, isFinished?: boolean) => void;
+  disablePast?: boolean;
   disableFuture?: boolean;
   autoSubmit?: boolean;
   showTabs?: boolean;

--- a/lib/src/DateTimePicker/DateTimePicker.jsx
+++ b/lib/src/DateTimePicker/DateTimePicker.jsx
@@ -21,6 +21,7 @@ export class DateTimePicker extends Component {
     onChange: PropTypes.func.isRequired,
     autoSubmit: PropTypes.bool,
     openTo: PropTypes.oneOf(Object.keys(viewType).map(key => viewType[key])),
+    disablePast: PropTypes.bool,
     disableFuture: PropTypes.bool,
     minDate: DomainPropTypes.date,
     maxDate: DomainPropTypes.date,
@@ -40,6 +41,7 @@ export class DateTimePicker extends Component {
     maxDate: '2100-01-01',
     autoSubmit: true,
     openTo: viewType.DATE,
+    disablePast: false,
     disableFuture: false,
     showTabs: true,
     leftArrowIcon: undefined,
@@ -88,6 +90,7 @@ export class DateTimePicker extends Component {
       minDate,
       maxDate,
       showTabs,
+      disablePast,
       disableFuture,
       leftArrowIcon,
       rightArrowIcon,
@@ -127,6 +130,7 @@ export class DateTimePicker extends Component {
             minDate={minDate}
             maxDate={maxDate}
             onChange={this.onChange(viewType.DATE)}
+            disablePast={disablePast}
             disableFuture={disableFuture}
             utils={utils}
           />
@@ -138,6 +142,7 @@ export class DateTimePicker extends Component {
             minDate={minDate}
             maxDate={maxDate}
             onChange={this.onChange(viewType.HOUR)}
+            disablePast={disablePast}
             disableFuture={disableFuture}
             leftArrowIcon={leftArrowIcon}
             rightArrowIcon={rightArrowIcon}

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
@@ -10,6 +10,7 @@ export interface DateTimePickerWrapperProps extends ModalWrapperProps {
   minDate?: DateType;
   maxDate?: DateType;
   onChange: (date: object) => void;
+  disablePast?: boolean;
   disableFuture?: boolean;
   autoOk?: boolean;
   autoSubmit?: boolean;

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
@@ -74,6 +74,7 @@ export class DateTimePickerWrapper extends PickerBase {
       maxDate,
       showTabs,
       autoSubmit,
+      disablePast,
       disableFuture,
       returnMoment,
       invalidLabel,
@@ -109,6 +110,7 @@ export class DateTimePickerWrapper extends PickerBase {
           openTo={openTo}
           autoSubmit={autoSubmit}
           onChange={this.handleChange}
+          disablePast={disablePast}
           disableFuture={disableFuture}
           minDate={minDate}
           maxDate={maxDate}


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

## Description
Works like `disableFuture`, but disables dates in the past. It doesn't disable current day or year, of course.
Also, I added `disableFuture` and `disablePast` to `DateTimePicker` props documentation, since they both are supported.