### PR TITLE
Fix autoOk option

### DIFF
--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -50,10 +50,6 @@ export default class PickerBase extends PureComponent {
       : this.default24hFormat;
   }
 
-  togglePicker = () => {
-    this.wrapper.togglePicker();
-  }
-
   handleAccept = () => {
     const dateToReturn = this.props.returnMoment
       ? this.state.date
@@ -70,7 +66,7 @@ export default class PickerBase extends PureComponent {
     this.setState({ date }, () => {
       if (isFinish && this.props.autoOk) {
         this.handleAccept();
-        this.togglePicker();
+        this.wrapper.close();
       }
     });
   }

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -34,19 +34,23 @@ export default class ModalWrapper extends PureComponent {
     open: false,
   }
 
-  handleClick = () => {
+  open = () => {
     this.setState({ open: true });
   }
 
-  handleAccept = () => {
+  close = () => {
     this.setState({ open: false });
+  }
+
+  handleAccept = () => {
+    this.close();
     if (this.props.onAccept) {
       this.props.onAccept();
     }
   }
 
   handleDismiss = () => {
-    this.setState({ open: false });
+    this.close();
     if (this.props.onDismiss) {
       this.props.onDismiss();
     }
@@ -72,7 +76,7 @@ export default class ModalWrapper extends PureComponent {
         <DateTextField
           value={value}
           format={format}
-          onClick={this.handleClick}
+          onClick={this.open}
           // onFocus={this.togglePicker} <- Currently not properly works with .blur() on TextField
           invalidLabel={invalidLabel}
           labelFunc={labelFunc}


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

## Description
Fixes #116

`ModalWrapper`'s `togglePicker` method [was removed](https://github.com/dmtrKovalenko/material-ui-pickers/pull/113/files#diff-72f4e6af722b05962c5307017df3a8b1L37), but it is still used by [`PickerBase`](https://github.com/dmtrKovalenko/material-ui-pickers/blob/develop/lib/src/_shared/PickerBase.jsx#L54)
This PR adds `open` and `close` convenience methods to `ModalWrapper` and changes `PickerBase` to use `wrapper.close` instead of `wrapper.togglePicker` method.