### PR TITLE
Typography fixes

### DIFF
--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -37,7 +37,13 @@ export const CalendarHeader = (props) => {
 
       <div className={classes.daysHeader}>
         {utils.getWeekdays().map(day => (
-          <div key={day} className={classes.dayLabel}> {day} </div>
+          <Typography
+            key={day}
+            type="caption"
+            className={classes.dayLabel}
+          >
+            {day}
+          </Typography>
         ))}
       </div>
     </div>
@@ -75,7 +81,6 @@ const styles = theme => ({
   dayLabel: {
     width: 36,
     margin: '0 2px',
-    fontSize: 13,
     textAlign: 'center',
     color: theme.palette.text.hint,
   },

--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withStyles, IconButton } from 'material-ui';
+import { withStyles, IconButton, Typography } from 'material-ui';
 import * as defaultUtils from '../utils/utils';
 
 export const CalendarHeader = (props) => {
@@ -26,9 +26,9 @@ export const CalendarHeader = (props) => {
           {rtl ? rightArrowIcon : leftArrowIcon}
         </IconButton>
 
-        <div className={classes.monthName}>
+        <Typography type="subheading">
           {utils.getCalendarHeaderText(currentMonth)}
-        </div>
+        </Typography>
 
         <IconButton onClick={selectNextMonth}>
           {rtl ? leftArrowIcon : rightArrowIcon}
@@ -78,9 +78,6 @@ const styles = theme => ({
     fontSize: 13,
     textAlign: 'center',
     color: theme.palette.text.hint,
-  },
-  monthName: {
-    color: theme.palette.text.primary,
   },
 });
 

--- a/lib/src/TimePicker/ClockNumber.jsx
+++ b/lib/src/TimePicker/ClockNumber.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { withStyles } from 'material-ui';
+import { Typography, withStyles } from 'material-ui';
 
 const positions = {
   0: [0, 40],
@@ -58,41 +58,42 @@ export class ClockNumber extends Component {
 
     const className = classnames(classes.clockNumber, {
       [classes.selected]: selected,
-      [classes.inner]: isInner,
     });
 
     return (
-      <div
+      <Typography
+        type={isInner ? 'body1' : 'subheading'}
+        component="span"
         className={className}
         style={this.getTransformStyle(index, isInner)}
       >
         { label }
-      </div>
+      </Typography>
     );
   }
 }
 
-const styles = theme => ({
-  clockNumber: {
-    width: 32,
-    height: 32,
-    position: 'absolute',
-    left: 'calc(50% - 16px)',
-    display: 'inline-flex',
-    justifyContent: 'center',
-    alignItems: 'center',
-    borderRadius: '50%',
-    color: theme.palette.type === 'light'
-      ? theme.palette.text.primary
-      : theme.palette.text.hint,
-  },
-  selected: {
-    color: 'white',
-  },
-  inner: {
-    fontSize: 14,
-  },
-});
+const styles = (theme) => {
+  const size = theme.spacing.unit * 4;
+  return {
+    clockNumber: {
+      width: size,
+      height: size,
+      position: 'absolute',
+      left: `calc(50% - ${size / 2}px)`,
+      display: 'inline-flex',
+      justifyContent: 'center',
+      alignItems: 'center',
+      borderRadius: '50%',
+      color: theme.palette.type === 'light'
+        ? theme.palette.text.primary
+        : theme.palette.text.hint,
+    },
+    selected: {
+      color: theme.palette.common.white,
+    },
+  };
+};
 
 export default withStyles(styles, { name: 'MuiPickersClockNumber' })(ClockNumber);
 


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
Some components do not use `Typography` from `material-ui`, that is why they inherit `font-family` styles and it looks ugly. 
The reason it looks alright on the demo page is that body has `font-family: sans-serif` CSS rule, which is specific for that page.
Here's a gif - I'm toggling that `font-family` rule on `body` tag:
![peek 2017-12-22 16-54](https://user-images.githubusercontent.com/13808724/34304173-d7e67a4a-e738-11e7-8839-763bb2bafa08.gif)

This PR changes those components to use `Typography`, so it will look good regardless of document styles.




