### PR TITLE
Improve Calendar accessibility

### DIFF
--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -99,15 +99,16 @@ export class Calendar extends Component {
     return week.map((day) => {
       // should be applied both for wrapper and button
       const disabledClass = classnames({ [classes.disabled]: this.shouldDisableDate(day) });
-
       const dayInCurrentMonth = utils.getMonthNumber(day) === currentMonthNumber;
+      const isHidden = !dayInCurrentMonth;
+
       const dayClass = classnames(classes.day, disabledClass, {
-        [classes.hidden]: !dayInCurrentMonth,
+        [classes.hidden]: isHidden,
         [classes.selected]: selectedDate.isSame(day, 'day'),
       });
 
       let dayComponent = (
-        <IconButton className={dayClass}>
+        <IconButton className={dayClass} tabIndex={isHidden ? -1 : 0}>
           <span> {utils.getDayText(day)} </span>
         </IconButton>
       );

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -37,7 +37,6 @@ const ModalDialog = ({
       <Button
         color="primary"
         onClick={onDismiss}
-        tabIndex={-1}
       >
         { cancelLabel }
       </Button>

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -37,6 +37,7 @@ const ModalDialog = ({
       <Button
         color="primary"
         onClick={onDismiss}
+        aria-label={cancelLabel}
       >
         { cancelLabel }
       </Button>
@@ -44,6 +45,7 @@ const ModalDialog = ({
       <Button
         color="primary"
         onClick={onAccept}
+        aria-label={okLabel}
       >
         { okLabel }
       </Button>


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
Improved `Calendar` accessibility:
- empty days can not be focused now - after focusing next month button first day of the month is focused:
![peek 2017-12-23 10-31](https://user-images.githubusercontent.com/13808724/34318774-645cfac0-e7d0-11e7-8bf2-4c532a497416.gif)
- cancel button is now focusable
- ok and cancel buttons now have `aria-label` attributes
