### PR TITLE
Open picker on enter press

### DIFF
--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -150,7 +150,6 @@ export default class DateTextField extends PureComponent {
         onClick={this.handleFocus}
         error={!!error}
         helperText={error}
-        onKeyPress={this.handleChange}
         onBlur={e => e.preventDefault() && e.stopPropagation()}
         disabled={disabled}
         value={displayValue}

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -106,6 +106,12 @@ export default class DateTextField extends PureComponent {
     this.openPicker(e);
   }
 
+  handleKeyPress = (e) => {
+    if (e.key === 'Enter') {
+      this.openPicker(e);
+    }
+  }
+
   openPicker = (e) => {
     const { disabled, onClick } = this.props;
 
@@ -150,6 +156,7 @@ export default class DateTextField extends PureComponent {
         onClick={this.handleFocus}
         error={!!error}
         helperText={error}
+        onKeyPress={this.handleKeyPress}
         onBlur={e => e.preventDefault() && e.stopPropagation()}
         disabled={disabled}
         value={displayValue}


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
`DateTextField` has `onChange` handler, which handles all changes.
`onKeyPress` duplicates them, which causes unnecessary rerenders.