### PR TITLE
Pass readOnly prop to TextField properly

### DIFF
--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -133,7 +133,10 @@ export default class DateTextField extends PureComponent {
 
     const localInputProps = {
       inputComponent: MaskedInput,
-      inputProps: { mask },
+      inputProps: {
+        mask,
+        readOnly: true,
+      },
     };
 
     if (keyboard) {
@@ -146,7 +149,6 @@ export default class DateTextField extends PureComponent {
 
     return (
       <TextField
-        readOnly
         onClick={this.handleFocus}
         error={!!error}
         helperText={error}

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -135,7 +135,7 @@ export default class DateTextField extends PureComponent {
       inputComponent: MaskedInput,
       inputProps: {
         mask,
-        readOnly: true,
+        readOnly: !keyboard,
       },
     };
 


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
This PR makes `DateTextField` read only. 
Fixes  this:
![peek 2017-12-26 20-57](https://user-images.githubusercontent.com/13808724/34363838-cf5048bc-ea7f-11e7-9e7e-af6cf98551eb.gif)
