### PR TITLE
Convert plain container div to Fragment

### DIFF
--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -1,4 +1,4 @@
-import React, { PureComponent } from 'react';
+import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import ModalDialog from '../_shared/ModalDialog';
 import DateTextField from '../_shared/DateTextField';
@@ -72,7 +72,7 @@ export default class ModalWrapper extends PureComponent {
     } = this.props;
 
     return (
-      <div>
+      <Fragment>
         <DateTextField
           value={value}
           format={format}
@@ -93,7 +93,7 @@ export default class ModalWrapper extends PureComponent {
         >
           {children}
         </ModalDialog>
-      </div>
+      </Fragment>
     );
   }
 }


### PR DESCRIPTION
This makes the text field element the root instead of the plain container div

Issue: #132 

