### PR TITLE
Add clear button

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,8 @@ onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
 okLabel | string | 'OK' | The label for the ok button
-cancelLabel | string | 'CANCEL' | The label for the cancel button
+cancelLabel | string | 'Cancel' | The label for the cancel button
+clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
 leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
@@ -120,7 +121,8 @@ onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
 okLabel | string | 'OK' | The label for the ok button
-cancelLabel | string | 'CANCEL' | The label for the cancel button
+cancelLabel | string | 'Cancel' | The label for the cancel button
+clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
 ampm | boolean | true | 12h/24h view for hour selection clock
 keyboard | boolean | false | Allow to manual input date to the text field
@@ -146,7 +148,8 @@ onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChangeg
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
 okLabel | string | 'OK' | The label for the ok button
-cancelLabel | string | 'CANCEL' | The label for the cancel button
+cancelLabel | string | 'Cancel' | The label for the cancel button
+clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
 leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable c
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
+clearable | boolean | true | Show clear button
 
 #### Timepicker
 Prop | Type | Default | Definition
@@ -125,6 +126,7 @@ ampm | boolean | true | 12h/24h view for hour selection clock
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
+clearable | boolean | true | Show clear button
 
 #### DateTimepicker
 Prop | Type | Default | Definition
@@ -157,6 +159,7 @@ keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 invalidDateMessage | string | 'Invalid Date Format' | Message, appearing when date cannot be parsed
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
+clearable | boolean | true | Show clear button
 
 ### l10n
 For l10n texts we're currently relying on moment which is stateful. To change the locale you have to import your langauge specific files an change the locale manually via `moment.locale(language)`.

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ emptyLabel | string | '' | Displayed string if date is `null` (e.g. after clear)
 okLabel | string | 'OK' | The label for the ok button
 cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
-labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
+labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
 leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
 rightArrowIcon | react node, string | 'keyboard_arrow_right'| Right arrow icon
@@ -125,7 +125,7 @@ emptyLabel | string | '' | Displayed string if date is `null` (e.g. after clear)
 okLabel | string | 'OK' | The label for the ok button
 cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
-labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
+labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 ampm | boolean | true | 12h/24h view for hour selection clock
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
@@ -153,7 +153,7 @@ emptyLabel | string | '' | Displayed string if date is `null` (e.g. after clear)
 okLabel | string | 'OK' | The label for the ok button
 cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
-labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`
+labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
 leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
 rightArrowIcon | react node, string | 'keyboard_arrow_right'| Right arrow icon

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ jMoment.loadPersian({ dialect: 'persian-modern', usePersianDigits: true });
 <DateTimePicker
   okLabel="تأیید"
   cancelLabel="لغو"
-  labelFunc={date => jMoment(date).format('jYYYY/jMM/jDD hh:mm A')}
+  labelFunc={date => date === null ? '' : jMoment(date).format('jYYYY/jMM/jDD hh:mm A')}
   value={selectedDate}
   onChange={this.handleDateChange}
   utils={jalaliUtils}

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable c
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
-clearable | boolean | true | Show clear button
+clearable | boolean | true | If `false`, clear button is not displayed
 
 #### Timepicker
 Prop | Type | Default | Definition
@@ -130,7 +130,7 @@ ampm | boolean | true | 12h/24h view for hour selection clock
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
-clearable | boolean | true | Show clear button
+clearable | boolean | true | If `false`, clear button is not displayed
 
 #### DateTimepicker
 Prop | Type | Default | Definition
@@ -165,7 +165,7 @@ keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 invalidDateMessage | string | 'Invalid Date Format' | Message, appearing when date cannot be parsed
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
-clearable | boolean | true | Show clear button
+clearable | boolean | true | If `false`, clear button is not displayed
 
 ### l10n
 For l10n texts we're currently relying on moment which is stateful. To change the locale you have to import your langauge specific files an change the locale manually via `moment.locale(language)`.

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ minDate | date | '1900-01-01' | Minimum selectable date
 maxDate | date | '2100-01-01' | Maximum selectable date
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
-invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
+invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed
+emptyLabel | string | '' | Displayed string if date is `null` (e.g. after clear)
 okLabel | string | 'OK' | The label for the ok button
 cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
@@ -119,7 +120,8 @@ format | string | 'MMMM Do' | Moment format string for input
 autoOk | boolean | false | Auto accept time on selection
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
-invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
+invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed
+emptyLabel | string | '' | Displayed string if date is `null` (e.g. after clear)
 okLabel | string | 'OK' | The label for the ok button
 cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
@@ -146,7 +148,8 @@ minDate | date | '1900-01-01' | Minimum selectable date
 maxDate | date | '2100-01-01' | Maximum selectable date
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChangeg
-invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed (or null)
+invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed
+emptyLabel | string | '' | Displayed string if date is `null` (e.g. after clear)
 okLabel | string | 'OK' | The label for the ok button
 cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button

--- a/docs/src/Demo/Examples/CustomElements.jsx
+++ b/docs/src/Demo/Examples/CustomElements.jsx
@@ -21,9 +21,16 @@ class CustomElements extends Component {
     this.setState({ selectedDate: date.clone().startOf('week') });
   }
 
-  formatWeekSelectLabel = (date, invalidLabel) => (date && date.isValid()
-    ? `Week of ${date.clone().startOf('week').format('MMM Do')}`
-    : invalidLabel)
+  formatWeekSelectLabel = (date, invalidLabel) => {
+    if (date === null) {
+      return '';
+    }
+
+    return date && date.isValid() ?
+      `Week of ${date.clone().startOf('week').format('MMM Do')}`
+      :
+      invalidLabel;
+  }
 
   renderCustomDayForDateTime = (date, selectedDate, dayInCurrentMonth, dayComponent) => {
     const { classes } = this.props;

--- a/docs/src/Demo/Examples/PersianPickers.jsx
+++ b/docs/src/Demo/Examples/PersianPickers.jsx
@@ -29,7 +29,7 @@ export default class BasicUsage extends Component {
           <DatePicker
             okLabel="تأیید"
             cancelLabel="لغو"
-            labelFunc={date => jMoment(date).format('jYYYY/jMM/jDD')}
+            labelFunc={date => date === null ? '' : jMoment(date).format('jYYYY/jMM/jDD')}
             value={selectedDate}
             onChange={this.handleDateChange}
             animateYearScrolling={false}
@@ -45,7 +45,7 @@ export default class BasicUsage extends Component {
           <TimePicker
             okLabel="تأیید"
             cancelLabel="لغو"
-            labelFunc={date => jMoment(date).format('hh:mm A')}
+            labelFunc={date => date === null ? '' : jMoment(date).format('hh:mm A')}
             value={selectedDate}
             onChange={this.handleDateChange}
             utils={jalaliUtils}
@@ -60,7 +60,7 @@ export default class BasicUsage extends Component {
           <DateTimePicker
             okLabel="تأیید"
             cancelLabel="لغو"
-            labelFunc={date => jMoment(date).format('jYYYY/jMM/jDD hh:mm A')}
+            labelFunc={date => date === null ? '' : jMoment(date).format('jYYYY/jMM/jDD hh:mm A')}
             value={selectedDate}
             onChange={this.handleDateChange}
             utils={jalaliUtils}

--- a/lib/package.json
+++ b/lib/package.json
@@ -54,7 +54,8 @@
     "prerelease": "npm run ci",
     "release": "np --no-publish --any-branch",
     "postrelease": "npm run build && npm publish build",
-    "lint": "eslint ./src/**/*.js*"
+    "lint": "eslint ./src/**/*.js*",
+    "lint-fix": "npm run lint -- --fix"
   },
   "devDependencies": {
     "babel-cli": "^6.24.1",

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -96,6 +96,7 @@ export default class DatePickerWrapper extends PickerBase {
         ref={(node) => { this.wrapper = node; }}
         value={value}
         format={format}
+        onClear={this.handleClear}
         onAccept={this.handleAccept}
         onChange={this.handleTextFieldChange}
         onDismiss={this.handleDismiss}

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
@@ -100,6 +100,7 @@ export class DateTimePickerWrapper extends PickerBase {
         onAccept={this.handleAccept}
         onChange={this.handleTextFieldChange}
         onDismiss={this.handleDismiss}
+        onClear={this.handleClear}
         dialogContentClassName={classes.dialogContent}
         invalidLabel={invalidLabel}
         labelFunc={labelFunc}

--- a/lib/src/TimePicker/TimePickerWrapper.jsx
+++ b/lib/src/TimePicker/TimePickerWrapper.jsx
@@ -48,6 +48,7 @@ export default class TimePickerWrapper extends PickerBase {
         ref={(node) => { this.wrapper = node; }}
         value={value}
         format={this.getFormat()}
+        onClear={this.handleClear}
         onAccept={this.handleAccept}
         onChange={this.handleTextFieldChange}
         onDismiss={this.handleDismiss}

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -141,7 +141,7 @@ export default class DateTextField extends PureComponent {
 
     const localInputProps = {
       inputComponent: MaskedInput,
-      inputProps: { mask },
+      inputProps: { mask: value === null ? null : mask },
     };
 
     if (keyboard) {

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -57,7 +57,7 @@ export default class DateTextField extends PureComponent {
     const date = moment(value);
 
     if (labelFunc) {
-      return labelFunc(date, invalidLabel);
+      return labelFunc(isEmpty ? null : date, invalidLabel);
     }
 
     if (isEmpty) {

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -22,6 +22,7 @@ export default class DateTextField extends PureComponent {
     onChange: PropTypes.func.isRequired,
     onClick: PropTypes.func.isRequired,
     invalidLabel: PropTypes.string,
+    emptyLabel: PropTypes.string,
     labelFunc: PropTypes.func,
     keyboard: PropTypes.bool,
     InputProps: PropTypes.shape(),
@@ -32,6 +33,7 @@ export default class DateTextField extends PureComponent {
   static defaultProps = {
     disabled: false,
     invalidLabel: 'Unknown',
+    emptyLabel: '',
     value: new Date(),
     labelFunc: undefined,
     format: undefined,
@@ -47,13 +49,19 @@ export default class DateTextField extends PureComponent {
       value,
       format,
       invalidLabel,
+      emptyLabel,
       labelFunc,
     } = props;
 
+    const isEmpty = value === null;
     const date = moment(value);
 
     if (labelFunc) {
       return labelFunc(date, invalidLabel);
+    }
+
+    if (isEmpty) {
+      return emptyLabel;
     }
 
     return date.isValid()
@@ -120,6 +128,7 @@ export default class DateTextField extends PureComponent {
       disabled,
       onClick,
       invalidLabel,
+      emptyLabel,
       labelFunc,
       keyboard,
       value,

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -15,13 +15,20 @@ const styles = {
       padding: 0,
     },
   },
+  dialogActions: {
+    '&:first-child': {
+      marginRight: 'auto',
+    },
+  },
 };
 
 const ModalDialog = ({
   children,
   classes,
+  onClear,
   onAccept,
   onDismiss,
+  clearLabel,
   okLabel,
   cancelLabel,
   dialogContentClassName,
@@ -32,7 +39,18 @@ const ModalDialog = ({
       { children }
     </DialogContent>
 
-    <DialogActions>
+    <DialogActions
+      classes={{
+        action: classes.dialogActions,
+      }}
+    >
+      <Button
+        color="primary"
+        onClick={onClear}
+        aria-label={clearLabel}
+      >
+        { clearLabel }
+      </Button>
       <Button
         color="primary"
         onClick={onDismiss}
@@ -57,16 +75,19 @@ ModalDialog.propTypes = {
   children: PropTypes.node.isRequired,
   onAccept: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
+  onClear: PropTypes.func.isRequired,
   classes: PropTypes.object.isRequired,
   dialogContentClassName: PropTypes.string,
   okLabel: PropTypes.string,
   cancelLabel: PropTypes.string,
+  clearLabel: PropTypes.string,
 };
 
 ModalDialog.defaultProps = {
   dialogContentClassName: '',
   okLabel: 'OK',
   cancelLabel: 'Cancel',
+  clearLabel: 'Clear',
 };
 
 export default withStyles(styles, { name: 'MuiPickersModal' })(ModalDialog);

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -25,13 +25,14 @@ const styles = {
 const ModalDialog = ({
   children,
   classes,
-  onClear,
   onAccept,
   onDismiss,
-  clearLabel,
+  onClear,
   okLabel,
   cancelLabel,
+  clearLabel,
   dialogContentClassName,
+  clearable,
   ...other
 }) => (
   <Dialog onClose={onDismiss} classes={{ paper: classes.dialogRoot }} {...other}>
@@ -41,16 +42,18 @@ const ModalDialog = ({
 
     <DialogActions
       classes={{
-        action: classes.dialogActions,
+        action: clearable && classes.dialogActions,
       }}
     >
-      <Button
-        color="primary"
-        onClick={onClear}
-        aria-label={clearLabel}
-      >
-        { clearLabel }
-      </Button>
+      {clearable &&
+        <Button
+          color="primary"
+          onClick={onClear}
+          aria-label={clearLabel}
+        >
+          { clearLabel }
+        </Button>
+      }
       <Button
         color="primary"
         onClick={onDismiss}
@@ -81,6 +84,7 @@ ModalDialog.propTypes = {
   okLabel: PropTypes.string,
   cancelLabel: PropTypes.string,
   clearLabel: PropTypes.string,
+  clearable: PropTypes.bool.isRequired,
 };
 
 ModalDialog.defaultProps = {

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -15,11 +15,6 @@ const styles = {
       padding: 0,
     },
   },
-  dialogActions: {
-    '&:first-child': {
-      marginRight: 'auto',
-    },
-  },
 };
 
 const ModalDialog = ({
@@ -40,11 +35,7 @@ const ModalDialog = ({
       { children }
     </DialogContent>
 
-    <DialogActions
-      classes={{
-        action: clearable && classes.dialogActions,
-      }}
-    >
+    <DialogActions>
       {clearable &&
         <Button
           color="primary"

--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -50,6 +50,10 @@ export default class PickerBase extends PureComponent {
       : this.default24hFormat;
   }
 
+  handleClear = () => {
+    this.props.onChange(null);
+  }
+
   handleAccept = () => {
     const dateToReturn = this.props.returnMoment
       ? this.state.date

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -18,6 +18,7 @@ export default class ModalWrapper extends PureComponent {
     okLabel: PropTypes.string,
     cancelLabel: PropTypes.string,
     clearLabel: PropTypes.string,
+    clearable: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -32,6 +33,7 @@ export default class ModalWrapper extends PureComponent {
     onAccept: undefined,
     onDismiss: undefined,
     onClear: undefined,
+    clearable: true,
   }
 
   state = {
@@ -81,6 +83,7 @@ export default class ModalWrapper extends PureComponent {
       okLabel,
       cancelLabel,
       clearLabel,
+      clearable,
       ...other
     } = this.props;
 
@@ -105,6 +108,7 @@ export default class ModalWrapper extends PureComponent {
           clearLabel={clearLabel}
           okLabel={okLabel}
           cancelLabel={cancelLabel}
+          clearable={clearable}
         >
           {children}
         </ModalDialog>

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -11,11 +11,13 @@ export default class ModalWrapper extends PureComponent {
     format: PropTypes.string,
     onAccept: PropTypes.func,
     onDismiss: PropTypes.func,
+    onClear: PropTypes.func,
     dialogContentClassName: PropTypes.string,
     invalidLabel: PropTypes.string,
     labelFunc: PropTypes.func,
     okLabel: PropTypes.string,
     cancelLabel: PropTypes.string,
+    clearLabel: PropTypes.string,
   }
 
   static defaultProps = {
@@ -25,9 +27,11 @@ export default class ModalWrapper extends PureComponent {
     labelFunc: undefined,
     okLabel: undefined,
     cancelLabel: undefined,
+    clearLabel: undefined,
     format: undefined,
     onAccept: undefined,
     onDismiss: undefined,
+    onClear: undefined,
   }
 
   state = {
@@ -56,6 +60,13 @@ export default class ModalWrapper extends PureComponent {
     }
   }
 
+  handleClear = () => {
+    this.close();
+    if (this.props.onClear) {
+      this.props.onClear();
+    }
+  }
+
   render() {
     const {
       value,
@@ -64,10 +75,12 @@ export default class ModalWrapper extends PureComponent {
       dialogContentClassName,
       onAccept,
       onDismiss,
+      onClear,
       invalidLabel,
       labelFunc,
       okLabel,
       cancelLabel,
+      clearLabel,
       ...other
     } = this.props;
 
@@ -85,9 +98,11 @@ export default class ModalWrapper extends PureComponent {
 
         <ModalDialog
           open={this.state.open}
+          onClear={this.handleClear}
           onAccept={this.handleAccept}
           onDismiss={this.handleDismiss}
           dialogContentClassName={dialogContentClassName}
+          clearLabel={clearLabel}
           okLabel={okLabel}
           cancelLabel={cancelLabel}
         >


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

Closes #29 
Closes #31 

## Description
This PR adds clear button:
![peek 2017-12-27 12-01](https://user-images.githubusercontent.com/13808724/34379855-a9871664-eafd-11e7-9ba0-290e3020cf97.gif)

# Breaking change:
`labelFunc` should handle `null` date value, which means that picker was cleared:
```diff
-labelFunc={(date) => {
-    return date && date.isValid() ? date.format() : 'Invalid date'; // invalidLabel
-}}

+labelFunc={(date) => {
+    if (date === null) {
+        return ''; // emptyLabel 
+    }
+    return date && date.isValid() ? date.format() : 'Invalid date'; // invalidLabel
+}}
```

# New props:
- `emptyLabel` - displayed string if date is `null` (e.g. after clear).
- `clearLabel` - label for the clear button
- `clearable` - if `false`, clear button is not displayed

# Misc:
- added `lint-fix` script to `package.json`