### PR TITLE
YearSelection fixes

### DIFF
--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -74,7 +74,7 @@ export class YearSelection extends PureComponent {
                   role="button"
                   key={utils.getYearText(year)}
                   className={className}
-                  tabIndex={yearNumber}
+                  tabIndex={0}
                   onClick={() => this.onYearSelect(yearNumber)}
                   onKeyPress={() => this.onYearSelect(yearNumber)}
                 >

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -62,12 +62,13 @@ export class YearSelection extends PureComponent {
             .map((year) => {
               const yearNumber = utils.getYear(year);
               const isSelected = yearNumber === currentYear;
+              const isDisabled = (
+                (disablePast && year.isBefore(moment(), 'year')) ||
+                (disableFuture && year.isAfter(moment(), 'year'))
+              );
               const className = classnames(classes.year, {
                 [classes.selectedYear]: isSelected,
-                [classes.disabled]: (
-                  (disablePast && year.isBefore(moment(), 'year')) ||
-                  (disableFuture && year.isAfter(moment(), 'year'))
-                ),
+                [classes.disabled]: isDisabled,
               });
 
               return (
@@ -76,7 +77,7 @@ export class YearSelection extends PureComponent {
                   component="div"
                   key={utils.getYearText(year)}
                   className={className}
-                  tabIndex={0}
+                  tabIndex={isDisabled ? -1 : 0}
                   onClick={() => this.onYearSelect(yearNumber)}
                   onKeyPress={() => this.onYearSelect(yearNumber)}
                   color={isSelected ? 'primary' : 'default'}

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -90,7 +90,7 @@ export class YearSelection extends PureComponent {
 
 const styles = theme => ({
   container: {
-    maxHeight: 320,
+    maxHeight: 300,
     overflowY: 'auto',
     justifyContent: 'center',
   },

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import Moment from 'moment';
 import classnames from 'classnames';
 import { extendMoment } from 'moment-range';
-import { withStyles } from 'material-ui';
+import { withStyles, Typography } from 'material-ui';
 import DomainPropTypes from '../constants/prop-types';
 import * as defaultUtils from '../utils/utils';
 
@@ -61,8 +61,9 @@ export class YearSelection extends PureComponent {
           Array.from(moment.range(minDate, maxDate).by('year'))
             .map((year) => {
               const yearNumber = utils.getYear(year);
-              const className = classnames(classes.yearItem, {
-                [classes.selectedYear]: yearNumber === currentYear,
+              const isSelected = yearNumber === currentYear;
+              const className = classnames(classes.year, {
+                [classes.selectedYear]: isSelected,
                 [classes.disabled]: (
                   (disablePast && year.isBefore(moment(), 'year')) ||
                   (disableFuture && year.isAfter(moment(), 'year'))
@@ -70,16 +71,19 @@ export class YearSelection extends PureComponent {
               });
 
               return (
-                <div
+                <Typography
                   role="button"
+                  component="div"
                   key={utils.getYearText(year)}
                   className={className}
                   tabIndex={0}
                   onClick={() => this.onYearSelect(yearNumber)}
                   onKeyPress={() => this.onYearSelect(yearNumber)}
+                  color={isSelected ? 'primary' : 'default'}
+                  type={isSelected ? 'headline' : 'subheading'}
                 >
                   {utils.getYearText(year)}
-                </div>
+                </Typography>
               );
             })
         }
@@ -94,19 +98,21 @@ const styles = theme => ({
     overflowY: 'auto',
     justifyContent: 'center',
   },
-  yearItem: {
-    height: 36,
+  year: {
+    height: theme.spacing.unit * 5,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
     cursor: 'pointer',
     outline: 'none',
-    color: theme.palette.text.primary,
+    '&:focus': {
+      color: theme.palette.primary[500],
+      fontWeight: theme.typography.fontWeightMedium,
+    },
   },
   selectedYear: {
-    fontSize: 26,
     margin: '10px 0',
-    color: theme.palette.primary[500],
+    fontWeight: theme.typography.fontWeightMedium,
   },
   disabled: {
     pointerEvents: 'none',


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
- use `Typography` for rendering years
- adjust `YearSelection` container height to match `Calendar` height and void "jumping" when switching between them
- properly handle `tabIndex`es
- mark focused year
- fix bug, when disabled year can be selected by focusing and pressing enter