### PR TITLE
trigger clear when the text field is empty with enabled keyboard mode

### DIFF
--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -92,13 +92,13 @@ export default class DateTextField extends PureComponent {
       format,
       invalidDateMessage,
       clearable,
-      onChange,
       onClear,
     } = this.props;
 
     if (clearable && e.target.value === '') {
-      onChange(null);
-      if (onClear) {
+      if (this.props.value === null) {
+        this.setState(this.updateState());
+      } else if (onClear) {
         onClear();
       }
 
@@ -115,7 +115,7 @@ export default class DateTextField extends PureComponent {
       error,
     }, () => {
       if (!error && newValue.format('LLLL') !== oldValue.format('LLLL')) {
-        onChange(newValue, true);
+        this.props.onChange(newValue, true);
       }
     });
   }

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -20,6 +20,7 @@ export default class DateTextField extends PureComponent {
     disabled: PropTypes.bool,
     format: PropTypes.string,
     onChange: PropTypes.func.isRequired,
+    onClear: PropTypes.func,
     onClick: PropTypes.func.isRequired,
     invalidLabel: PropTypes.string,
     emptyLabel: PropTypes.string,
@@ -28,6 +29,7 @@ export default class DateTextField extends PureComponent {
     InputProps: PropTypes.shape(),
     keyboardIcon: PropTypes.node,
     invalidDateMessage: PropTypes.string,
+    clearable: PropTypes.bool,
   }
 
   static defaultProps = {
@@ -42,6 +44,8 @@ export default class DateTextField extends PureComponent {
     mask: undefined,
     keyboardIcon: 'event',
     invalidDateMessage: 'Invalid Date Format',
+    clearable: true,
+    onClear: undefined,
   }
 
   getDisplayDate = (props) => {
@@ -84,7 +88,23 @@ export default class DateTextField extends PureComponent {
   }
 
   handleChange = (e) => {
-    const { format, invalidDateMessage } = this.props;
+    const {
+      format,
+      invalidDateMessage,
+      clearable,
+      onChange,
+      onClear,
+    } = this.props;
+
+    if (clearable && e.target.value === '') {
+      onChange(null);
+      if (onClear) {
+        onClear();
+      }
+
+      return;
+    }
+
     const oldValue = moment(this.state.value);
     const newValue = moment(e.target.value, format, true);
     const error = newValue.isValid() ? '' : invalidDateMessage;
@@ -95,7 +115,7 @@ export default class DateTextField extends PureComponent {
       error,
     }, () => {
       if (!error && newValue.format('LLLL') !== oldValue.format('LLLL')) {
-        this.props.onChange(newValue, true);
+        onChange(newValue, true);
       }
     });
   }
@@ -135,6 +155,8 @@ export default class DateTextField extends PureComponent {
       onClick,
       invalidLabel,
       invalidDateMessage,
+      clearable,
+      onClear,
       emptyLabel,
       labelFunc,
       keyboard,

--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -77,7 +77,7 @@ export default class PickerBase extends PureComponent {
 
   handleTextFieldChange = (date) => {
     if (date === null) {
-      this.props.onChange(null);
+      this.handleClear();
     } else {
       this.setState({ date }, this.handleAccept);
     }

--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -76,6 +76,10 @@ export default class PickerBase extends PureComponent {
   }
 
   handleTextFieldChange = (date) => {
-    this.setState({ date }, this.handleAccept);
+    if (date === null) {
+      this.props.onChange(null);
+    } else {
+      this.setState({ date }, this.handleAccept);
+    }
   }
 }

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -77,7 +77,6 @@ export default class ModalWrapper extends PureComponent {
       dialogContentClassName,
       onAccept,
       onDismiss,
-      onClear,
       invalidLabel,
       labelFunc,
       okLabel,
@@ -96,6 +95,7 @@ export default class ModalWrapper extends PureComponent {
           // onFocus={this.togglePicker} <- Currently not properly works with .blur() on TextField
           invalidLabel={invalidLabel}
           labelFunc={labelFunc}
+          clearable={clearable}
           {...other}
         />
 


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
This pull requests changes the behavior of the text field when **clearable** and **keyboard** options are enabled.

**Action:** remove all characters in the text field
**Before:** invalidate date warning is shown and date is not changed
**With this pull request:** same behavior as when the clear button is clicked (no invalid message and the date is changed)