### PR TITLE
Avoid passing anonymous functions as props

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@
   "rules": {
     "react/forbid-prop-types": 0,
     "react/jsx-filename-extension": 0,
+    "react/no-find-dom-node": 0,
     "no-param-reassign": 0,
     "import/no-named-as-default": 0,
     "import/no-extraneous-dependencies": 0

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -100,7 +100,8 @@ export class Calendar extends Component {
 
     return week.map((day) => {
       // should be applied both for wrapper and button
-      const disabledClass = classnames({ [classes.disabled]: this.shouldDisableDate(day) });
+      const disabled = this.shouldDisableDate(day);
+      const disabledClass = classnames({ [classes.disabled]: disabled });
       const dayInCurrentMonth = utils.getMonthNumber(day) === currentMonthNumber;
       const isHidden = !dayInCurrentMonth;
 
@@ -125,6 +126,7 @@ export class Calendar extends Component {
           key={day.toString()}
           day={day}
           dayInCurrentMonth={dayInCurrentMonth}
+          disabled={disabled}
           onSelect={this.onDateSelect}
         >
           {dayComponent}

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -8,6 +8,7 @@ import classnames from 'classnames';
 import CalendarHeader from './CalendarHeader';
 import DomainPropTypes from '../constants/prop-types';
 import * as defaultUtils from '../utils/utils';
+import DayWrapper from './DayWrapper';
 
 const moment = extendMoment(Moment);
 
@@ -120,15 +121,15 @@ export class Calendar extends Component {
       }
 
       return (
-        <div
-          key={day.toString()}
-          onClick={() => dayInCurrentMonth && this.onDateSelect(day)}
-          onKeyPress={() => dayInCurrentMonth && this.onDateSelect(day)}
+        <DayWrapper
           className={disabledClass}
-          role="presentation"
+          key={day.toString()}
+          day={day}
+          dayInCurrentMonth={dayInCurrentMonth}
+          onSelect={this.onDateSelect}
         >
           {dayComponent}
-        </div>
+        </DayWrapper>
       );
     });
   }

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -122,7 +122,6 @@ export class Calendar extends Component {
 
       return (
         <DayWrapper
-          className={disabledClass}
           key={day.toString()}
           day={day}
           dayInCurrentMonth={dayInCurrentMonth}

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -1,14 +1,14 @@
 import React, { Component, Fragment } from 'react';
 import PropTypes from 'prop-types';
-import { withStyles, IconButton } from 'material-ui';
+import { withStyles } from 'material-ui';
 
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
-import classnames from 'classnames';
 import CalendarHeader from './CalendarHeader';
 import DomainPropTypes from '../constants/prop-types';
 import * as defaultUtils from '../utils/utils';
 import DayWrapper from './DayWrapper';
+import Day from './Day';
 
 const moment = extendMoment(Moment);
 
@@ -91,7 +91,7 @@ export class Calendar extends Component {
 
   renderDays = (week) => {
     const {
-      classes, date, renderDay, utils,
+      date, renderDay, utils,
     } = this.props;
 
     const selectedDate = date.clone().startOf('day');
@@ -99,22 +99,18 @@ export class Calendar extends Component {
     const now = moment();
 
     return week.map((day) => {
-      // should be applied both for wrapper and button
       const disabled = this.shouldDisableDate(day);
-      const disabledClass = classnames({ [classes.disabled]: disabled });
       const dayInCurrentMonth = utils.getMonthNumber(day) === currentMonthNumber;
-      const isHidden = !dayInCurrentMonth;
-
-      const dayClass = classnames(classes.day, disabledClass, {
-        [classes.hidden]: isHidden,
-        [classes.current]: day.isSame(now, 'day'),
-        [classes.selected]: selectedDate.isSame(day, 'day'),
-      });
 
       let dayComponent = (
-        <IconButton className={dayClass} tabIndex={isHidden ? -1 : 0}>
-          <span> {utils.getDayText(day)} </span>
-        </IconButton>
+        <Day
+          current={day.isSame(now, 'day')}
+          hidden={!dayInCurrentMonth}
+          disabled={disabled}
+          selected={selectedDate.isSame(day, 'day')}
+        >
+          {utils.getDayText(day)}
+        </Day>
       );
 
       if (renderDay) {
@@ -161,31 +157,6 @@ const styles = theme => ({
   calendar: {
     height: 36 * 6,
     marginTop: theme.spacing.unit * 1.5,
-  },
-  hidden: {
-    opacity: 0,
-    pointerEvents: 'none',
-  },
-  day: {
-    width: 36,
-    height: 36,
-    fontSize: theme.typography.caption.fontSize,
-    margin: '0 2px',
-    color: theme.palette.text.primary,
-    fontWeight: theme.typography.fontWeightMedium,
-  },
-  current: {
-    color: theme.palette.primary[500],
-    fontWeight: 600,
-  },
-  selected: {
-    color: theme.palette.common.white,
-    backgroundColor: theme.palette.primary[500],
-    fontWeight: theme.typography.fontWeightMedium,
-  },
-  disabled: {
-    pointerEvents: 'none',
-    color: theme.palette.text.hint,
   },
   week: {
     display: 'flex',

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -120,7 +120,7 @@ export class Calendar extends Component {
       return (
         <DayWrapper
           key={day.toString()}
-          day={day}
+          value={day}
           dayInCurrentMonth={dayInCurrentMonth}
           disabled={disabled}
           onSelect={this.onDateSelect}

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -67,6 +67,8 @@ export default class DatePickerWrapper extends PickerBase {
     shouldDisableDate: undefined,
   }
 
+  getRef = (node) => { this.wrapper = node; }
+
   render() {
     const { date } = this.state;
     const {
@@ -93,7 +95,7 @@ export default class DatePickerWrapper extends PickerBase {
 
     return (
       <ModalWrapper
-        ref={(node) => { this.wrapper = node; }}
+        ref={this.getRef}
         value={value}
         format={format}
         onClear={this.handleClear}

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -67,8 +67,6 @@ export default class DatePickerWrapper extends PickerBase {
     shouldDisableDate: undefined,
   }
 
-  getRef = (node) => { this.wrapper = node; }
-
   render() {
     const { date } = this.state;
     const {

--- a/lib/src/DatePicker/Day.d.ts
+++ b/lib/src/DatePicker/Day.d.ts
@@ -1,0 +1,13 @@
+import { ComponentClass, ReactNode } from 'react';
+
+export interface DayProps {
+    children: ReactNode;
+    current?: boolean;
+    disabled?: boolean;
+    hidden?: boolean;
+    selected?: boolean;
+}
+
+declare const Day: ComponentClass<DayProps>;
+
+export default Day;

--- a/lib/src/DatePicker/Day.jsx
+++ b/lib/src/DatePicker/Day.jsx
@@ -1,0 +1,76 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { IconButton, withStyles } from 'material-ui';
+import classnames from 'classnames';
+
+class Day extends PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    classes: PropTypes.object.isRequired,
+    disabled: PropTypes.bool,
+    hidden: PropTypes.bool,
+    current: PropTypes.bool,
+    selected: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    disabled: false,
+    hidden: false,
+    current: false,
+    selected: false,
+  }
+
+  render() {
+    const {
+      children, classes, disabled, hidden, current, selected, ...other
+    } = this.props;
+
+    const className = classnames(classes.day, {
+      [classes.hidden]: hidden,
+      [classes.current]: current,
+      [classes.selected]: selected,
+      [classes.disabled]: disabled,
+    });
+
+    return (
+      <IconButton
+        className={className}
+        tabIndex={hidden || disabled ? -1 : 0}
+        {...other}
+      >
+        <span> {children} </span>
+      </IconButton>
+    );
+  }
+}
+
+const styles = theme => ({
+  day: {
+    width: 36,
+    height: 36,
+    fontSize: theme.typography.caption.fontSize,
+    margin: '0 2px',
+    color: theme.palette.text.primary,
+    fontWeight: theme.typography.fontWeightMedium,
+  },
+  hidden: {
+    opacity: 0,
+    pointerEvents: 'none',
+  },
+  current: {
+    color: theme.palette.primary[500],
+    fontWeight: 600,
+  },
+  selected: {
+    color: theme.palette.common.white,
+    backgroundColor: theme.palette.primary[500],
+    fontWeight: theme.typography.fontWeightMedium,
+  },
+  disabled: {
+    pointerEvents: 'none',
+    color: theme.palette.text.hint,
+  },
+});
+
+export default withStyles(styles)(Day);

--- a/lib/src/DatePicker/Day.jsx
+++ b/lib/src/DatePicker/Day.jsx
@@ -8,9 +8,9 @@ class Day extends PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     classes: PropTypes.object.isRequired,
+    current: PropTypes.bool,
     disabled: PropTypes.bool,
     hidden: PropTypes.bool,
-    current: PropTypes.bool,
     selected: PropTypes.bool,
   }
 

--- a/lib/src/DatePicker/DayWrapper.d.ts
+++ b/lib/src/DatePicker/DayWrapper.d.ts
@@ -1,0 +1,13 @@
+import { ComponentClass, ReactNode } from 'react';
+
+export interface DayWrapperProps {
+    children: ReactNode;
+    dayInCurrentMonth?: boolean,
+    disabled?: boolean;
+    onSelect: (value: any) => void;
+    value: any;
+}
+
+declare const DayWrapper: ComponentClass<DayWrapperProps>;
+
+export default DayWrapper;

--- a/lib/src/DatePicker/DayWrapper.jsx
+++ b/lib/src/DatePicker/DayWrapper.jsx
@@ -1,0 +1,26 @@
+import React, { PureComponent } from 'react';
+
+class Day extends PureComponent {
+
+  handleClick = () => {
+    this.props.onSelect(this.props.day);
+  }
+
+  render() {
+    const {
+      children, day, dayInCurrentMonth, onSelect, ...other
+    } = this.props;
+    return (
+      <div
+        onClick={dayInCurrentMonth ? this.handleClick : undefined}
+        onKeyPress={dayInCurrentMonth ? this.handleClick : undefined}
+        role="presentation"
+        {...other}
+      >
+        {children}
+      </div>
+    )
+  }
+}
+
+export default Day;

--- a/lib/src/DatePicker/DayWrapper.jsx
+++ b/lib/src/DatePicker/DayWrapper.jsx
@@ -5,7 +5,7 @@ class DayWrapper extends PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     onSelect: PropTypes.func.isRequired,
-    day: PropTypes.any.isRequired,
+    value: PropTypes.any.isRequired,
     dayInCurrentMonth: PropTypes.bool,
     disabled: PropTypes.bool,
   }
@@ -16,12 +16,12 @@ class DayWrapper extends PureComponent {
   }
 
   handleClick = () => {
-    this.props.onSelect(this.props.day);
+    this.props.onSelect(this.props.value);
   }
 
   render() {
     const {
-      children, day, dayInCurrentMonth, disabled, onSelect, ...other
+      children, value, dayInCurrentMonth, disabled, onSelect, ...other
     } = this.props;
     return (
       <div

--- a/lib/src/DatePicker/DayWrapper.jsx
+++ b/lib/src/DatePicker/DayWrapper.jsx
@@ -1,6 +1,17 @@
 import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
 
 class Day extends PureComponent {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    onSelect: PropTypes.func.isRequired,
+    dayInCurrentMonth: PropTypes.bool,
+    day: PropTypes.any.isRequired,
+  }
+
+  static defaultProps = {
+    dayInCurrentMonth: true,
+  }
 
   handleClick = () => {
     this.props.onSelect(this.props.day);
@@ -19,7 +30,7 @@ class Day extends PureComponent {
       >
         {children}
       </div>
-    )
+    );
   }
 }
 

--- a/lib/src/DatePicker/DayWrapper.jsx
+++ b/lib/src/DatePicker/DayWrapper.jsx
@@ -1,7 +1,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
-class Day extends PureComponent {
+class DayWrapper extends PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     onSelect: PropTypes.func.isRequired,
@@ -34,4 +34,4 @@ class Day extends PureComponent {
   }
 }
 
-export default Day;
+export default DayWrapper;

--- a/lib/src/DatePicker/DayWrapper.jsx
+++ b/lib/src/DatePicker/DayWrapper.jsx
@@ -5,12 +5,14 @@ class DayWrapper extends PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
     onSelect: PropTypes.func.isRequired,
-    dayInCurrentMonth: PropTypes.bool,
     day: PropTypes.any.isRequired,
+    dayInCurrentMonth: PropTypes.bool,
+    disabled: PropTypes.bool,
   }
 
   static defaultProps = {
     dayInCurrentMonth: true,
+    disabled: false,
   }
 
   handleClick = () => {
@@ -19,12 +21,12 @@ class DayWrapper extends PureComponent {
 
   render() {
     const {
-      children, day, dayInCurrentMonth, onSelect, ...other
+      children, day, dayInCurrentMonth, disabled, onSelect, ...other
     } = this.props;
     return (
       <div
-        onClick={dayInCurrentMonth ? this.handleClick : undefined}
-        onKeyPress={dayInCurrentMonth ? this.handleClick : undefined}
+        onClick={dayInCurrentMonth && !disabled ? this.handleClick : undefined}
+        onKeyPress={dayInCurrentMonth && !disabled ? this.handleClick : undefined}
         role="presentation"
         {...other}
       >

--- a/lib/src/DatePicker/DayWrapper.jsx
+++ b/lib/src/DatePicker/DayWrapper.jsx
@@ -4,10 +4,10 @@ import PropTypes from 'prop-types';
 class DayWrapper extends PureComponent {
   static propTypes = {
     children: PropTypes.node.isRequired,
-    onSelect: PropTypes.func.isRequired,
-    value: PropTypes.any.isRequired,
     dayInCurrentMonth: PropTypes.bool,
     disabled: PropTypes.bool,
+    onSelect: PropTypes.func.isRequired,
+    value: PropTypes.any.isRequired,
   }
 
   static defaultProps = {

--- a/lib/src/DatePicker/Year.d.ts
+++ b/lib/src/DatePicker/Year.d.ts
@@ -1,0 +1,13 @@
+import { ComponentClass, ReactNode } from 'react';
+
+export interface YearProps {
+    children: ReactNode;
+    disabled?: boolean;
+    onSelect: (year: number) => void;
+    selected?: boolean;
+    year: number;
+}
+
+declare const Year: ComponentClass<YearProps>;
+
+export default Year;

--- a/lib/src/DatePicker/Year.d.ts
+++ b/lib/src/DatePicker/Year.d.ts
@@ -3,9 +3,9 @@ import { ComponentClass, ReactNode } from 'react';
 export interface YearProps {
     children: ReactNode;
     disabled?: boolean;
-    onSelect: (year: number) => void;
+    onSelect: (value: any) => void;
     selected?: boolean;
-    year: number;
+    value: any;
 }
 
 declare const Year: ComponentClass<YearProps>;

--- a/lib/src/DatePicker/Year.jsx
+++ b/lib/src/DatePicker/Year.jsx
@@ -6,12 +6,12 @@ import classnames from 'classnames';
 
 class Year extends PureComponent {
   static propTypes = {
-    children: PropTypes.element.isRequired,
+    children: PropTypes.node.isRequired,
     classes: PropTypes.object.isRequired,
     disabled: PropTypes.bool,
     onSelect: PropTypes.func.isRequired,
     selected: PropTypes.bool,
-    year: PropTypes.string.isRequired,
+    year: PropTypes.number.isRequired,
   }
 
   static defaultProps = {

--- a/lib/src/DatePicker/Year.jsx
+++ b/lib/src/DatePicker/Year.jsx
@@ -1,0 +1,75 @@
+import React, { PureComponent } from 'react';
+import PropTypes from 'prop-types';
+
+import { withStyles, Typography } from 'material-ui';
+import classnames from 'classnames';
+
+class Year extends PureComponent {
+  static propTypes = {
+    children: PropTypes.element.isRequired,
+    classes: PropTypes.object.isRequired,
+    disabled: PropTypes.bool,
+    onSelect: PropTypes.func.isRequired,
+    selected: PropTypes.bool,
+    year: PropTypes.string.isRequired,
+  }
+
+  static defaultProps = {
+    selected: false,
+    disabled: false,
+  }
+
+  handleClick = () => {
+    this.props.onSelect(this.props.year);
+  }
+
+  render() {
+    const {
+      classes, selected, disabled, year, children, ...other
+    } = this.props;
+
+    return (
+      <Typography
+        role="button"
+        component="div"
+        className={classnames(classes.root, {
+          [classes.selected]: selected,
+          [classes.disabled]: disabled,
+        })}
+        tabIndex={disabled ? -1 : 0}
+        onClick={this.handleClick}
+        onKeyPress={this.handleClick}
+        color={selected ? 'primary' : 'default'}
+        type={selected ? 'headline' : 'subheading'}
+        {...other}
+      >
+        {children}
+      </Typography>
+    );
+  }
+}
+
+const styles = theme => ({
+  root: {
+    height: theme.spacing.unit * 5,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    cursor: 'pointer',
+    outline: 'none',
+    '&:focus': {
+      color: theme.palette.primary[500],
+      fontWeight: theme.typography.fontWeightMedium,
+    },
+  },
+  selected: {
+    margin: '10px 0',
+    fontWeight: theme.typography.fontWeightMedium,
+  },
+  disabled: {
+    pointerEvents: 'none',
+    color: theme.palette.text.hint,
+  },
+});
+
+export default withStyles(styles)(Year);

--- a/lib/src/DatePicker/Year.jsx
+++ b/lib/src/DatePicker/Year.jsx
@@ -11,7 +11,7 @@ class Year extends PureComponent {
     disabled: PropTypes.bool,
     onSelect: PropTypes.func.isRequired,
     selected: PropTypes.bool,
-    year: PropTypes.number.isRequired,
+    value: PropTypes.any.isRequired,
   }
 
   static defaultProps = {
@@ -20,12 +20,12 @@ class Year extends PureComponent {
   }
 
   handleClick = () => {
-    this.props.onSelect(this.props.year);
+    this.props.onSelect(this.props.value);
   }
 
   render() {
     const {
-      classes, selected, disabled, year, children, ...other
+      classes, selected, disabled, value, children, ...other
     } = this.props;
 
     return (

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -1,5 +1,6 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import { findDOMNode } from 'react-dom';
 import Moment from 'moment';
 import { extendMoment } from 'moment-range';
 import { withStyles } from 'material-ui';
@@ -38,9 +39,13 @@ export class YearSelection extends PureComponent {
     onChange(newDate);
   }
 
+  getSelectedYearRef = (ref) => {
+    this.selectedYearRef = ref;
+  }
+
   scrollToCurrentYear = () => {
-    const { animateYearScrolling, classes } = this.props;
-    const currentYearElement = document.getElementsByClassName(classes.selected)[0];
+    const { animateYearScrolling } = this.props;
+    const currentYearElement = findDOMNode(this.selectedYearRef);
 
     if (currentYearElement) {
       currentYearElement.scrollIntoView({
@@ -48,6 +53,8 @@ export class YearSelection extends PureComponent {
       });
     }
   }
+
+  selectedYearRef = undefined;
 
   render() {
     const {
@@ -61,10 +68,11 @@ export class YearSelection extends PureComponent {
           Array.from(moment.range(minDate, maxDate).by('year'))
             .map((year) => {
               const yearNumber = utils.getYear(year);
+              const selected = yearNumber === currentYear;
 
               return (
                 <Year
-                  selected={yearNumber === currentYear}
+                  selected={selected}
                   disabled={(
                     (disablePast && year.isBefore(moment(), 'year')) ||
                     (disableFuture && year.isAfter(moment(), 'year'))
@@ -72,6 +80,10 @@ export class YearSelection extends PureComponent {
                   year={yearNumber}
                   key={utils.getYearText(year)}
                   onSelect={this.onYearSelect}
+                  ref={selected
+                    ? this.getSelectedYearRef
+                    : undefined
+                  }
                 >
                   {utils.getYearText(year)}
                 </Year>

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -1,11 +1,11 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import Moment from 'moment';
-import classnames from 'classnames';
 import { extendMoment } from 'moment-range';
-import { withStyles, Typography } from 'material-ui';
+import { withStyles } from 'material-ui';
 import DomainPropTypes from '../constants/prop-types';
 import * as defaultUtils from '../utils/utils';
+import Year from './Year';
 
 const moment = extendMoment(Moment);
 
@@ -40,7 +40,7 @@ export class YearSelection extends PureComponent {
 
   scrollToCurrentYear = () => {
     const { animateYearScrolling, classes } = this.props;
-    const currentYearElement = document.getElementsByClassName(classes.selectedYear)[0];
+    const currentYearElement = document.getElementsByClassName(classes.selected)[0];
 
     if (currentYearElement) {
       currentYearElement.scrollIntoView({
@@ -61,30 +61,20 @@ export class YearSelection extends PureComponent {
           Array.from(moment.range(minDate, maxDate).by('year'))
             .map((year) => {
               const yearNumber = utils.getYear(year);
-              const isSelected = yearNumber === currentYear;
-              const isDisabled = (
-                (disablePast && year.isBefore(moment(), 'year')) ||
-                (disableFuture && year.isAfter(moment(), 'year'))
-              );
-              const className = classnames(classes.year, {
-                [classes.selectedYear]: isSelected,
-                [classes.disabled]: isDisabled,
-              });
 
               return (
-                <Typography
-                  role="button"
-                  component="div"
+                <Year
+                  selected={yearNumber === currentYear}
+                  disabled={(
+                    (disablePast && year.isBefore(moment(), 'year')) ||
+                    (disableFuture && year.isAfter(moment(), 'year'))
+                  )}
+                  year={yearNumber}
                   key={utils.getYearText(year)}
-                  className={className}
-                  tabIndex={isDisabled ? -1 : 0}
-                  onClick={() => this.onYearSelect(yearNumber)}
-                  onKeyPress={() => this.onYearSelect(yearNumber)}
-                  color={isSelected ? 'primary' : 'default'}
-                  type={isSelected ? 'headline' : 'subheading'}
+                  onSelect={this.onYearSelect}
                 >
                   {utils.getYearText(year)}
-                </Typography>
+                </Year>
               );
             })
         }
@@ -93,32 +83,12 @@ export class YearSelection extends PureComponent {
   }
 }
 
-const styles = theme => ({
+const styles = {
   container: {
     maxHeight: 300,
     overflowY: 'auto',
     justifyContent: 'center',
   },
-  year: {
-    height: theme.spacing.unit * 5,
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'center',
-    cursor: 'pointer',
-    outline: 'none',
-    '&:focus': {
-      color: theme.palette.primary[500],
-      fontWeight: theme.typography.fontWeightMedium,
-    },
-  },
-  selectedYear: {
-    margin: '10px 0',
-    fontWeight: theme.typography.fontWeightMedium,
-  },
-  disabled: {
-    pointerEvents: 'none',
-    color: theme.palette.text.hint,
-  },
-});
+};
 
 export default withStyles(styles, { name: 'MuiPickersYearSelection' })(YearSelection);

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -77,7 +77,7 @@ export class YearSelection extends PureComponent {
                     (disablePast && year.isBefore(moment(), 'year')) ||
                     (disableFuture && year.isAfter(moment(), 'year'))
                   )}
-                  year={yearNumber}
+                  value={yearNumber}
                   key={utils.getYearText(year)}
                   onSelect={this.onYearSelect}
                   ref={selected

--- a/lib/src/DateTimePicker/DateTimePicker.jsx
+++ b/lib/src/DateTimePicker/DateTimePicker.jsx
@@ -60,7 +60,7 @@ export class DateTimePicker extends Component {
     meridiemMode: this.props.date.hours() >= 12 ? 'pm' : 'am',
   }
 
-  onChange = nextView => (time, isFinish = true) => {
+  onChange = (time, isFinish = true, nextView) => {
     this.handleChange(time);
 
     if (isFinish && this.props.autoSubmit) {
@@ -82,6 +82,18 @@ export class DateTimePicker extends Component {
   handleChange = (time, isFinish = false) => {
     const withMeridiem = convertToMeridiem(time, this.state.meridiemMode, this.props.ampm);
     this.props.onChange(withMeridiem, isFinish);
+  }
+
+  handleYearChange = (date, isFinish) => {
+    this.onChange(date, isFinish, viewType.DATE);
+  }
+
+  handleDayChange = (date, isFinish) => {
+    this.onChange(date, isFinish, viewType.HOUR);
+  }
+
+  handleHourChange = (time, isFinish) => {
+    this.onChange(time, isFinish, viewType.MINUTES);
   }
 
   render() {
@@ -131,7 +143,7 @@ export class DateTimePicker extends Component {
             date={date}
             minDate={minDate}
             maxDate={maxDate}
-            onChange={this.onChange(viewType.DATE)}
+            onChange={this.handleYearChange}
             disablePast={disablePast}
             disableFuture={disableFuture}
             utils={utils}
@@ -144,7 +156,7 @@ export class DateTimePicker extends Component {
             date={date}
             minDate={minDate}
             maxDate={maxDate}
-            onChange={this.onChange(viewType.HOUR)}
+            onChange={this.handleDayChange}
             disablePast={disablePast}
             disableFuture={disableFuture}
             leftArrowIcon={leftArrowIcon}
@@ -159,7 +171,7 @@ export class DateTimePicker extends Component {
           <HourView
             date={date}
             meridiemMode={meridiemMode}
-            onChange={this.onChange(viewType.MINUTES)}
+            onChange={this.handleHourChange}
             utils={utils}
             ampm={ampm}
           />

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.jsx
@@ -94,7 +94,7 @@ export class DateTimePickerWrapper extends PickerBase {
 
     return (
       <ModalWrapper
-        ref={(node) => { this.wrapper = node; }}
+        ref={this.getRef}
         value={value}
         format={this.getFormat()}
         onAccept={this.handleAccept}

--- a/lib/src/TimePicker/TimePicker.jsx
+++ b/lib/src/TimePicker/TimePicker.jsx
@@ -33,11 +33,11 @@ export class TimePicker extends Component {
   setMeridiemMode = mode => () => {
     this.setState(
       { meridiemMode: mode },
-      () => this.handleChange(false)(this.props.date, false),
+      () => this.handleChange(this.props.date, false, false),
     );
   }
 
-  handleChange = openMinutes => (time, isFinish) => {
+  handleChange(time, isFinish, openMinutes) {
     const withMeridiem = convertToMeridiem(time, this.state.meridiemMode, this.props.ampm);
 
     if (isFinish) {
@@ -50,6 +50,15 @@ export class TimePicker extends Component {
     }
 
     this.props.onChange(withMeridiem, false);
+  }
+
+
+  handleHourChange = (time, isFinish) => {
+    this.handleChange(time, isFinish, true);
+  }
+
+  handleMinutesChange = (time, isFinish) => {
+    this.handleChange(time, isFinish, false);
   }
 
   openMinutesView = () => {
@@ -128,14 +137,14 @@ export class TimePicker extends Component {
               <HourView
                 date={date}
                 meridiemMode={meridiemMode}
-                onChange={this.handleChange(true)}
+                onChange={this.handleHourChange}
                 utils={utils}
                 ampm={ampm}
               />
             :
               <MinutesView
                 date={date}
-                onChange={this.handleChange(false)}
+                onChange={this.handleMinutesChange}
                 utils={utils}
               />
         }

--- a/lib/src/TimePicker/TimePickerWrapper.jsx
+++ b/lib/src/TimePicker/TimePickerWrapper.jsx
@@ -45,7 +45,7 @@ export default class TimePickerWrapper extends PickerBase {
 
     return (
       <ModalWrapper
-        ref={(node) => { this.wrapper = node; }}
+        ref={this.getRef}
         value={value}
         format={this.getFormat()}
         onClear={this.handleClear}

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -87,6 +87,11 @@ export default class DateTextField extends PureComponent {
     }
   }
 
+  handleBlur = (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+  };
+
   handleChange = (e) => {
     const {
       format,
@@ -190,7 +195,7 @@ export default class DateTextField extends PureComponent {
         error={!!error}
         helperText={error}
         onKeyPress={this.handleKeyPress}
-        onBlur={e => e.preventDefault() && e.stopPropagation()}
+        onBlur={this.handleBlur}
         disabled={disabled}
         value={displayValue}
         {...other}

--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -50,6 +50,8 @@ export default class PickerBase extends PureComponent {
       : this.default24hFormat;
   }
 
+  getRef = (node) => { this.wrapper = node; }
+
   handleClear = () => {
     this.props.onChange(null);
   }


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
This PR aims to remove passing anonymous functions as props.
When passing anonymous arrow function as a prop - new function is created every time component is rendered, so if it's passed to `PureComponent` - `shouldComponentUpdate` will return `true` every time.
Also, often anonymous arrow functions use closure, which may cause performance issues.

Here's what changed:
- added `Year` component with simple API, used by `YearSelection`
- used `ref` for scrolling to selected year instead of `document.getElementsByClassName`
- added `Day` and `DayWrapper` components with simple API, used by `Calendar`
- removed anonymous functions whenever possible