### PR TITLE
Fix jss array-like margin

### DIFF
--- a/lib/src/TimePicker/Clock.jsx
+++ b/lib/src/TimePicker/Clock.jsx
@@ -121,7 +121,7 @@ const styles = theme => ({
     display: 'flex',
     justifyContent: 'center',
     alignItems: 'flex-end',
-    margin: [theme.spacing.unit * 4, 0, theme.spacing.unit],
+    margin: [[theme.spacing.unit * 4, 0, theme.spacing.unit]],
   },
   clock: {
     backgroundColor: 'rgba(0,0,0,.07)',


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
In mui-beta.22 `jss-expand` plugin was removed, so previous syntax doesn't work anymore.

It works on our demo page, because it uses `jss-preset-default`, which contains `jss-expand` plugin.