### PR TITLE
Add `TextField` prop to DatePicker, DateTimePicker, TimePicker

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
-TextField | func, string | undefined | Component that should replace the default Material-UI TextField
+TextFieldComponent | func, string | undefined | Component that should replace the default Material-UI TextField
 
 #### Timepicker
 Prop | Type | Default | Definition
@@ -132,7 +132,7 @@ keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
-TextField | func, string | undefined | Component that should replace the default Material-UI TextField
+TextFieldComponent | func, string | undefined | Component that should replace the default Material-UI TextField
 
 #### DateTimepicker
 Prop | Type | Default | Definition
@@ -168,7 +168,7 @@ keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 invalidDateMessage | string | 'Invalid Date Format' | Message, appearing when date cannot be parsed
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
-TextField | func, string | undefined | Component that should replace the default Material-UI TextField
+TextFieldComponent | func, string | undefined | Component that should replace the default Material-UI TextField
 
 ### l10n
 For l10n texts we're currently relying on moment which is stateful. To change the locale you have to import your langauge specific files an change the locale manually via `moment.locale(language)`.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
+TextField | func, string | undefined | Component that should replace the default Material-UI TextField
 
 #### Timepicker
 Prop | Type | Default | Definition
@@ -131,6 +132,7 @@ keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
+TextField | func, string | undefined | Component that should replace the default Material-UI TextField
 
 #### DateTimepicker
 Prop | Type | Default | Definition
@@ -166,6 +168,7 @@ keyboardIcon | react node, string | 'event' | Keyboard adornment icon
 invalidDateMessage | string | 'Invalid Date Format' | Message, appearing when date cannot be parsed
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
+TextField | func, string | undefined | Component that should replace the default Material-UI TextField
 
 ### l10n
 For l10n texts we're currently relying on moment which is stateful. To change the locale you have to import your langauge specific files an change the locale manually via `moment.locale(language)`.

--- a/lib/__tests__/_shared/DateTextField.test.js
+++ b/lib/__tests__/_shared/DateTextField.test.js
@@ -14,3 +14,26 @@ describe('DateTextField', () => {
     expect(component).toBeTruthy();
   });
 });
+
+describe('DateTextField with custom TextField', () => {
+  it('Should handle a component function', () => {
+    function CustomTextField(props) {
+      return (
+        <li {...props} />
+      );
+    }
+
+    const component = shallow(<DateTextField TextField={CustomTextField} />);
+
+    // Check InputProps to make sure DateTextField is passing props to the custom component
+    expect(component.prop('InputProps')).toBeTruthy();
+    expect(component.find('li')).toBeTruthy();
+  });
+
+  it('Should handle a component string', () => {
+    const component = shallow(<DateTextField TextField="li" />);
+
+    expect(component.prop('InputProps')).toBeTruthy();
+    expect(component.find('li')).toBeTruthy();
+  });
+});

--- a/lib/__tests__/_shared/DateTextField.test.js
+++ b/lib/__tests__/_shared/DateTextField.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import DateTextField from '../../src/_shared/DateTextField';
 
 describe('DateTextField', () => {
@@ -23,7 +23,7 @@ describe('DateTextField with custom TextField', () => {
       );
     }
 
-    const component = shallow(<DateTextField TextField={CustomTextField} />);
+    const component = shallow(<DateTextField TextFieldComponent={CustomTextField} />);
 
     // Check InputProps to make sure DateTextField is passing props to the custom component
     expect(component.prop('InputProps')).toBeTruthy();
@@ -31,9 +31,15 @@ describe('DateTextField with custom TextField', () => {
   });
 
   it('Should handle a component string', () => {
-    const component = shallow(<DateTextField TextField="li" />);
+    const component = shallow(<DateTextField TextFieldComponent="li" />);
 
     expect(component.prop('InputProps')).toBeTruthy();
     expect(component.find('li')).toBeTruthy();
+  });
+
+  it('Should not handle a node', () => {
+    expect(() => {
+      mount(<DateTextField TextFieldComponent={<div />} />);
+    }).toThrow();
   });
 });

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { TextField, InputAdornment, IconButton, Icon } from 'material-ui';
+import { TextField as MuiTextField, InputAdornment, IconButton, Icon } from 'material-ui';
 
 import MaskedInput from './MaskedInput';
 
@@ -30,6 +30,7 @@ export default class DateTextField extends PureComponent {
     keyboardIcon: PropTypes.node,
     invalidDateMessage: PropTypes.string,
     clearable: PropTypes.bool,
+    TextField: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   }
 
   static defaultProps = {
@@ -46,6 +47,7 @@ export default class DateTextField extends PureComponent {
     invalidDateMessage: 'Invalid Date Format',
     clearable: false,
     onClear: undefined,
+    TextField: undefined,
   }
 
   getDisplayDate = (props) => {
@@ -169,6 +171,7 @@ export default class DateTextField extends PureComponent {
       mask,
       InputProps,
       keyboardIcon,
+      TextField = MuiTextField,
       ...other
     } = this.props;
     const { displayValue, error } = this.state;

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -2,7 +2,7 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 import moment from 'moment';
-import { TextField as MuiTextField, InputAdornment, IconButton, Icon } from 'material-ui';
+import { TextField, InputAdornment, IconButton, Icon } from 'material-ui';
 
 import MaskedInput from './MaskedInput';
 
@@ -30,7 +30,7 @@ export default class DateTextField extends PureComponent {
     keyboardIcon: PropTypes.node,
     invalidDateMessage: PropTypes.string,
     clearable: PropTypes.bool,
-    TextField: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
+    TextFieldComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
   }
 
   static defaultProps = {
@@ -47,7 +47,7 @@ export default class DateTextField extends PureComponent {
     invalidDateMessage: 'Invalid Date Format',
     clearable: false,
     onClear: undefined,
-    TextField: undefined,
+    TextFieldComponent: TextField,
   }
 
   getDisplayDate = (props) => {
@@ -171,7 +171,7 @@ export default class DateTextField extends PureComponent {
       mask,
       InputProps,
       keyboardIcon,
-      TextField = MuiTextField,
+      TextFieldComponent,
       ...other
     } = this.props;
     const { displayValue, error } = this.state;
@@ -193,7 +193,7 @@ export default class DateTextField extends PureComponent {
     }
 
     return (
-      <TextField
+      <TextFieldComponent
         onClick={this.handleFocus}
         error={!!error}
         helperText={error}


### PR DESCRIPTION
- [ x] I have changed my target branch to **develop** :facepunch:

#161 

## Description
Add `TextField` prop to DatePicker, DateTimePicker, TimePicker
Update prop documentation to reflect new prop
Add tests
