### PR TITLE
Add typescript usage tests and fix typescript definition errors - integrate with CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ yarn-error.log*
 
 # webstorm
 .idea/
+/lib/yarn.lock
+/docs/yarn.lock

--- a/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
+++ b/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
@@ -13,8 +13,8 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleChange = (date: Moment) => {
-    this.setState({ selectedDate: date.toDate() });
+  handleChange = (date: Moment | Date) => {
+    this.setState({ selectedDate: date as Date });
   }
 
   render() {
@@ -42,12 +42,8 @@ class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleDateChange = (date: Moment) => {
-    this.setState({ selectedDate: date.toDate() });
-  }
-
-  handleWeekChange = (date: Moment) => {
-    this.setState({ selectedDate: date.startOf('week').toDate() });
+  handleDateChange = (date: Moment | Date) => {
+    this.setState({ selectedDate: (date as Moment).toDate() });
   }
 
   formatWeekSelectLabel = (date: Moment, invalidLabel: string) => {
@@ -106,6 +102,7 @@ class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
           onChange={this.handleDateChange}
           renderDay={this.renderWrappedDefaultDay}
           labelFunc={this.formatWeekSelectLabel}
+          returnMoment
         />
       </Fragment>
     );

--- a/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
+++ b/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { Fragment, Component } from 'react';
+import DatePickerWrapper  from '../../src/DatePicker/DatePickerWrapper';
+
+// FIXME: src vs exported component names a source of confusion
+// FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
+
+// initially from the docs site
+export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
+  state = {
+    selectedDate: new Date(),
+  }
+
+  handleChange = (date: Date) => {
+    this.setState({ selectedDate: date });
+  }
+
+  render() {
+    const { selectedDate } = this.state;
+
+    return (
+      <Fragment>
+        <DatePickerWrapper
+          keyboard
+          clearable
+          value={selectedDate}
+          onChange={this.handleChange}
+          animateYearScrolling={false}
+        />
+      </Fragment>
+    );
+  }
+}

--- a/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
+++ b/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
@@ -1,9 +1,11 @@
 import * as React from 'react'
+import * as PropTypes from 'prop-types';
 import { Fragment, Component } from 'react';
 import DatePickerWrapper  from '../../src/DatePicker/DatePickerWrapper';
-
-// FIXME: src vs exported component names a source of confusion
-// FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
+import { IconButton } from 'material-ui'
+import * as classNames from 'classnames';
+import { Moment } from 'moment'
+import { DayComponent } from '../../src/DatePicker/Calendar'
 
 // initially from the docs site
 export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
@@ -11,8 +13,8 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleChange = (date: Date) => {
-    this.setState({ selectedDate: date });
+  handleChange = (date: Moment) => {
+    this.setState({ selectedDate: date.toDate() });
   }
 
   render() {
@@ -26,6 +28,84 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
           value={selectedDate}
           onChange={this.handleChange}
           animateYearScrolling={false}
+        />
+      </Fragment>
+    );
+  }
+}
+
+class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
+  static propTypes = {
+    classes: PropTypes.object.isRequired,
+  }
+  state = {
+    selectedDate: new Date(),
+  }
+
+  handleDateChange = (date: Moment) => {
+    this.setState({ selectedDate: date.toDate() });
+  }
+
+  handleWeekChange = (date: Moment) => {
+    this.setState({ selectedDate: date.startOf('week').toDate() });
+  }
+
+  formatWeekSelectLabel = (date: Moment, invalidLabel: string) => {
+    if (date === null) {
+      return '';
+    }
+
+    return date && date.isValid() ?
+      `Week of ${date.clone().startOf('week').format('MMM Do')}`
+      :
+      invalidLabel;
+  }
+
+  renderWrappedDefaultDay = (day: Moment, selectedDate: Moment, dayInCurrentMonth: boolean, dayComponent: DayComponent) => {
+    const { classes } = this.props;
+
+    const startDate = selectedDate.clone().day(0).startOf('day');
+    const endDate = selectedDate.clone().day(6).endOf('day');
+
+    const dayIsBetween = (
+      day.isSame(startDate) ||
+      day.isSame(endDate) ||
+      (day.isAfter(startDate) && day.isBefore(endDate))
+    );
+
+    const firstDay = day.isSame(startDate, 'day');
+    const lastDay = day.isSame(endDate, 'day');
+
+    const wrapperClassName = classNames({
+      [classes.highlight]: dayIsBetween,
+      [classes.firstHighlight]: firstDay,
+      [classes.endHighlight]: lastDay,
+    });
+
+    const dayClassName = classNames(classes.day, {
+      [classes.nonCurrentMonthDay]: !dayInCurrentMonth,
+      [classes.highlightNonCurrentMonthDay]: !dayInCurrentMonth && dayIsBetween,
+    });
+
+    return (
+      <div className={wrapperClassName}>
+        <IconButton className={dayClassName}>
+          <span> { day.format('DD')} </span>
+        </IconButton>
+      </div>
+    );
+  }
+
+  render() {
+    const { selectedDate } = this.state;
+
+    return (
+      <Fragment>
+        <DatePickerWrapper
+          value={selectedDate}
+          onChange={this.handleDateChange}
+          renderDay={this.renderWrappedDefaultDay}
+          labelFunc={this.formatWeekSelectLabel}
         />
       </Fragment>
     );

--- a/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
+++ b/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react'
+import { Fragment, Component } from 'react';
+import { IconButton, Typography, Icon } from 'material-ui';
+import InputAdornment  from 'material-ui/Input/InputAdornment';
+import DateTimePickerWrapper  from '../../src/DateTimePicker/DateTimePickerWrapper';
+import {DateTimePickerView} from '../../src/constants/date-picker-view'
+
+// FIXME: src vs exported component names a source of confusion
+// FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
+
+// initially from the docs site
+export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
+  state = {
+    selectedDate: new Date(),
+  }
+
+  handleChange = (date: Date) => {
+    this.setState({ selectedDate: date });
+  }
+
+  render() {
+    const { selectedDate } = this.state;
+
+    return (
+      <Fragment>
+        <div className="picker">
+          <Typography type="headline" align="center" gutterBottom>
+            Default
+          </Typography>
+
+          <DateTimePickerWrapper
+            value={selectedDate}
+            onChange={this.handleChange}
+            leftArrowIcon={<Icon> keyboard_arrow_left </Icon>}
+            rightArrowIcon={<Icon> keyboard_arrow_right </Icon>}
+          />
+        </div>
+
+        <div className="picker">
+          <Typography type="headline" align="center" gutterBottom>
+            Custom
+          </Typography>
+
+          <DateTimePickerWrapper
+            error
+            autoOk
+            ampm={false}
+            showTabs={false}
+            autoSubmit={false}
+            disableFuture
+            value={selectedDate}
+            onChange={this.handleChange}
+            helperText="Required"
+            leftArrowIcon={<Icon> add_alarm </Icon>}
+            rightArrowIcon={<Icon> snooze </Icon>}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton>  add_alarm  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+          />
+        </div>
+      </Fragment>
+    );
+  }
+}

--- a/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
+++ b/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
@@ -3,7 +3,6 @@ import { Fragment, Component } from 'react';
 import { IconButton, Typography, Icon } from 'material-ui';
 import InputAdornment  from 'material-ui/Input/InputAdornment';
 import DateTimePickerWrapper  from '../../src/DateTimePicker/DateTimePickerWrapper';
-import {DateTimePickerView} from '../../src/constants/date-picker-view'
 
 // FIXME: src vs exported component names a source of confusion
 // FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
@@ -23,45 +22,33 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
 
     return (
       <Fragment>
-        <div className="picker">
-          <Typography type="headline" align="center" gutterBottom>
-            Default
-          </Typography>
+        <DateTimePickerWrapper
+          value={selectedDate}
+          onChange={this.handleChange}
+          leftArrowIcon={<Icon> keyboard_arrow_left </Icon>}
+          rightArrowIcon={<Icon> keyboard_arrow_right </Icon>}
+        />
 
-          <DateTimePickerWrapper
-            value={selectedDate}
-            onChange={this.handleChange}
-            leftArrowIcon={<Icon> keyboard_arrow_left </Icon>}
-            rightArrowIcon={<Icon> keyboard_arrow_right </Icon>}
-          />
-        </div>
-
-        <div className="picker">
-          <Typography type="headline" align="center" gutterBottom>
-            Custom
-          </Typography>
-
-          <DateTimePickerWrapper
-            error
-            autoOk
-            ampm={false}
-            showTabs={false}
-            autoSubmit={false}
-            disableFuture
-            value={selectedDate}
-            onChange={this.handleChange}
-            helperText="Required"
-            leftArrowIcon={<Icon> add_alarm </Icon>}
-            rightArrowIcon={<Icon> snooze </Icon>}
-            InputProps={{
-              endAdornment: (
-                <InputAdornment position="end">
-                  <IconButton>  add_alarm  </IconButton>
-                </InputAdornment>
-              ),
-            }}
-          />
-        </div>
+        <DateTimePickerWrapper
+          error
+          autoOk
+          ampm={false}
+          showTabs={false}
+          autoSubmit={false}
+          disableFuture
+          value={selectedDate}
+          onChange={this.handleChange}
+          helperText="Required"
+          leftArrowIcon={<Icon> add_alarm </Icon>}
+          rightArrowIcon={<Icon> snooze </Icon>}
+          InputProps={{
+            endAdornment: (
+              <InputAdornment position="end">
+                <IconButton>  add_alarm  </IconButton>
+              </InputAdornment>
+            ),
+          }}
+        />
       </Fragment>
     );
   }

--- a/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
+++ b/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
@@ -17,8 +17,8 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleChange = (date: Moment) => {
-    this.setState({ selectedDate: date.toDate() });
+  handleChange = (date: Moment | Date) => {
+    this.setState({ selectedDate: date as Date });
   }
 
   render() {
@@ -67,8 +67,8 @@ class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleDateChange = (date: Moment) => {
-    this.setState({ selectedDate: date.toDate() });
+  handleDateChange = (date: Moment | Date) => {
+    this.setState({ selectedDate: (date as Moment).toDate() });
   }
 
   renderCustomDayForDateTime = (day: Moment, selectedDate: Moment, dayInCurrentMonth: boolean, dayComponent: DayComponent) => {
@@ -96,6 +96,7 @@ class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
           value={selectedDate}
           onChange={this.handleDateChange}
           renderDay={this.renderCustomDayForDateTime}
+          returnMoment
         />
       </Fragment>
     );

--- a/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
+++ b/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
@@ -3,6 +3,10 @@ import { Fragment, Component } from 'react';
 import { IconButton, Typography, Icon } from 'material-ui';
 import InputAdornment  from 'material-ui/Input/InputAdornment';
 import DateTimePickerWrapper  from '../../src/DateTimePicker/DateTimePickerWrapper';
+import * as classNames from 'classnames'
+import { Moment } from 'moment'
+import * as PropTypes from 'prop-types'
+import {DayComponent} from '../../src/DatePicker/Calendar'
 
 // FIXME: src vs exported component names a source of confusion
 // FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
@@ -13,8 +17,8 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleChange = (date: Date) => {
-    this.setState({ selectedDate: date });
+  handleChange = (date: Moment) => {
+    this.setState({ selectedDate: date.toDate() });
   }
 
   render() {
@@ -48,6 +52,50 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
               </InputAdornment>
             ),
           }}
+        />
+      </Fragment>
+    );
+  }
+}
+
+
+class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
+  static propTypes = {
+    classes: PropTypes.object.isRequired,
+  }
+  state = {
+    selectedDate: new Date(),
+  }
+
+  handleDateChange = (date: Moment) => {
+    this.setState({ selectedDate: date.toDate() });
+  }
+
+  renderCustomDayForDateTime = (day: Moment, selectedDate: Moment, dayInCurrentMonth: boolean, dayComponent: DayComponent) => {
+    const { classes } = this.props;
+
+    const dayClassName = classNames({
+      [classes.customDayHighlight]: day.isSame(selectedDate, 'day'),
+    });
+
+    return (
+      <div className={classes.dayWrapper}>
+        {dayComponent}
+        <div className={dayClassName} />
+      </div>
+    );
+  }
+
+  render() {
+    const { selectedDate } = this.state;
+
+    return (
+      <Fragment>
+        <DateTimePickerWrapper
+          autoSubmit={false}
+          value={selectedDate}
+          onChange={this.handleDateChange}
+          renderDay={this.renderCustomDayForDateTime}
         />
       </Fragment>
     );

--- a/lib/__tests__/TimePicker/TimePickerWrapper.usage.tsx
+++ b/lib/__tests__/TimePicker/TimePickerWrapper.usage.tsx
@@ -1,0 +1,33 @@
+import * as React from 'react'
+import { Fragment, Component } from 'react';
+import TimePickerWrapper  from '../../src/TimePicker/TimePickerWrapper';
+
+// FIXME: src vs exported component names a source of confusion
+// FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
+
+// initially from the docs site
+export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
+  state = {
+    selectedDate: new Date(),
+  }
+
+  handleChange = (date: Date) => {
+    this.setState({ selectedDate: date });
+  }
+
+  render() {
+    const { selectedDate } = this.state;
+
+    return (
+      <Fragment>
+        <TimePickerWrapper
+          keyboard
+          mask={[/\d/, /\d/, ':', /\d/, /\d/, ' ', /a|p/i, 'M']}
+          placeholder="08:00 AM"
+          value={selectedDate}
+          onChange={this.handleChange}
+        />
+      </Fragment>
+    );
+  }
+}

--- a/lib/__tests__/TimePicker/TimePickerWrapper.usage.tsx
+++ b/lib/__tests__/TimePicker/TimePickerWrapper.usage.tsx
@@ -9,8 +9,8 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleChange = (date: Moment) => {
-    this.setState({ selectedDate: date.toDate() });
+  handleChange = (date: Moment | Date) => {
+    this.setState({ selectedDate: (date as Date) });
   }
 
   render() {

--- a/lib/__tests__/TimePicker/TimePickerWrapper.usage.tsx
+++ b/lib/__tests__/TimePicker/TimePickerWrapper.usage.tsx
@@ -1,9 +1,7 @@
 import * as React from 'react'
 import { Fragment, Component } from 'react';
 import TimePickerWrapper  from '../../src/TimePicker/TimePickerWrapper';
-
-// FIXME: src vs exported component names a source of confusion
-// FIXME https://github.com/dmtrKovalenko/material-ui-pickers/issues/169
+import { Moment } from 'moment'
 
 // initially from the docs site
 export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
@@ -11,8 +9,8 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
     selectedDate: new Date(),
   }
 
-  handleChange = (date: Date) => {
-    this.setState({ selectedDate: date });
+  handleChange = (date: Moment) => {
+    this.setState({ selectedDate: date.toDate() });
   }
 
   render() {

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -145,16 +145,37 @@
         }
       }
     },
+    "@types/classnames": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.3.tgz",
+      "integrity": "sha512-x15/Io+JdzrkM9gnX6SWUs/EmqQzd65TD9tcZIAQ1VIdb93XErNuYmB7Yho8JUCE189ipUSESsWvGvYXRRIvYA==",
+      "dev": true
+    },
     "@types/jss": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.3.0.tgz",
       "integrity": "sha512-n7MUYCO/Wt4d6Yj0ZewXSSkqBcrdLFgpQ4mUBRXBWDmLfXtgT3tJ26GVPr8HiyRLLze6iQfaBJTlvjRTjgZpRg==",
       "dev": true
     },
+    "@types/moment": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/@types/moment/-/moment-2.13.0.tgz",
+      "integrity": "sha1-YE69GJvDvDShVIaJQE5hoqSqyJY=",
+      "dev": true,
+      "requires": {
+        "moment": "2.20.1"
+      }
+    },
     "@types/node": {
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
       "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+      "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.5.2",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.5.2.tgz",
+      "integrity": "sha512-pQRkAVoxiuUrLq8+CDwiQX4pTCep/PmmNgBbjIwnnsd/HoYjGpR81+FFPE030lvNXgR0haaAU6eoRtztWDE4Xw==",
       "dev": true
     },
     "@types/react": {

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -145,10 +145,22 @@
         }
       }
     },
+    "@types/jss": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.3.0.tgz",
+      "integrity": "sha512-n7MUYCO/Wt4d6Yj0ZewXSSkqBcrdLFgpQ4mUBRXBWDmLfXtgT3tJ26GVPr8HiyRLLze6iQfaBJTlvjRTjgZpRg==",
+      "dev": true
+    },
     "@types/node": {
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.2.tgz",
       "integrity": "sha512-KA4GKOpgXnrqEH2eCVhiv2CsxgXGQJgV1X0vsGlh+WCnxbeAE1GT44ZsTU1IN5dEeV/gDupKa7gWo08V5IxWVQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "16.0.34",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.34.tgz",
+      "integrity": "sha512-Ee66fX2qMsDnDq7sPnDtq1bGoo479j6Fo1BlSnne+L5rp6ndzBUgz72+MRNuN56zg9uuteRCkJAMdDJEX2Uqig==",
       "dev": true
     },
     "abab": {
@@ -8325,6 +8337,12 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
+    },
+    "typescript": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
+      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
       "dev": true
     },
     "ua-parser-js": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -60,7 +60,10 @@
     "lint-fix": "npm run lint -- --fix"
   },
   "devDependencies": {
+    "@types/classnames": "^2.2.3",
     "@types/jss": "^9.3.0",
+    "@types/moment": "^2.13.0",
+    "@types/prop-types": "^15.5.2",
     "@types/react": "^16.0.34",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",

--- a/lib/package.json
+++ b/lib/package.json
@@ -32,19 +32,20 @@
     "email": "dmtr.kovalenko@outlook.com"
   },
   "peerDependencies": {
-    "react": "^16.2.0",
-    "react-dom": "^16.2.0",
-    "prop-types": "^15.6.0",
-    "material-ui": "^1.0.0-beta.24",
     "classnames": "^2.2.5",
-    "moment": "^2.19.2"
+    "material-ui": "^1.0.0-beta.24",
+    "moment": "^2.19.2",
+    "prop-types": "^15.6.0",
+    "react": "^16.2.0",
+    "react-dom": "^16.2.0"
   },
   "dependencies": {
     "moment-range": "^3.0.3",
     "react-text-mask": "^5.0.2"
   },
   "scripts": {
-    "test": "jest",
+    "test": "jest && npm run typescript",
+    "typescript": "tsc -p tsconfig.json",
     "start": "cross-env NODE_ENV=development rollup --config --watch",
     "prebuild": "rimraf build",
     "build:copy": "node copy.js",
@@ -59,6 +60,8 @@
     "lint-fix": "npm run lint -- --fix"
   },
   "devDependencies": {
+    "@types/jss": "^9.3.0",
+    "@types/react": "^16.0.34",
     "babel-cli": "^6.24.1",
     "babel-core": "^6.24.1",
     "babel-eslint": "^8.0.1",
@@ -93,7 +96,8 @@
     "rollup-plugin-babel": "^3.0.2",
     "rollup-plugin-commonjs": "^8.2.4",
     "rollup-plugin-filesize": "^1.5.0",
-    "rollup-plugin-node-resolve": "^3.0.0"
+    "rollup-plugin-node-resolve": "^3.0.0",
+    "typescript": "^2.6.2"
   },
   "jest": {
     "setupTestFrameworkScriptFile": "<rootDir>/__tests__/setup.js",

--- a/lib/src/DatePicker/Calendar.d.ts
+++ b/lib/src/DatePicker/Calendar.d.ts
@@ -19,7 +19,7 @@ export interface CalendarProps {
     date: object;
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: object) => void;
+    onChange: (date: Date) => void;
     disablePast?: boolean;
     disableFuture?: boolean;
     leftArrowIcon?: ReactNode;

--- a/lib/src/DatePicker/Calendar.d.ts
+++ b/lib/src/DatePicker/Calendar.d.ts
@@ -16,7 +16,7 @@ export type RenderDay =
 
 
 export interface CalendarProps {
-    date: object;
+    date: Moment;
     minDate?: DateType;
     maxDate?: DateType;
     onChange: (date: Moment) => void;

--- a/lib/src/DatePicker/Calendar.d.ts
+++ b/lib/src/DatePicker/Calendar.d.ts
@@ -4,22 +4,22 @@ import { DateType } from '../constants/prop-types';
 import { Utils } from '../utils/utils';
 import { Moment } from 'moment';
 
-type DayComponent = ReactElement<IconButtonProps>;
+export type DayComponent = ReactElement<IconButtonProps>;
 
-export interface RenderDay {
+export type RenderDay =
     (
-        day: object,
-        selectedDate: object,
+        day: Moment,
+        selectedDate: Moment,
         dayInCurrentMonth: boolean,
         dayComponent: DayComponent,
-    ): ReactNode;
-}
+    ) => ReactNode;
+
 
 export interface CalendarProps {
     date: object;
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: Date) => void;
+    onChange: (date: Moment) => void;
     disablePast?: boolean;
     disableFuture?: boolean;
     leftArrowIcon?: ReactNode;

--- a/lib/src/DatePicker/CalendarHeader.d.ts
+++ b/lib/src/DatePicker/CalendarHeader.d.ts
@@ -1,9 +1,10 @@
 import { ComponentClass, ReactNode } from 'react';
 import { Utils } from '../utils/utils';
+import { Moment } from 'moment';
 
 export interface CalendarHeaderProps {
     currentMonth: object;
-    onMonthChange: (date: object) => void;
+    onMonthChange: (date: Moment) => void;
     leftArrowIcon?: ReactNode;
     rightArrowIcon?: ReactNode;
     utils?: Utils;

--- a/lib/src/DatePicker/DatePicker.d.ts
+++ b/lib/src/DatePicker/DatePicker.d.ts
@@ -8,7 +8,7 @@ export interface DatePickerProps {
     date: object;
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: Date, isFinished?: boolean) => void;
+    onChange: (date: Moment, isFinished?: boolean) => void;
     disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;

--- a/lib/src/DatePicker/DatePicker.d.ts
+++ b/lib/src/DatePicker/DatePicker.d.ts
@@ -8,7 +8,7 @@ export interface DatePickerProps {
     date: object;
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: object, isFinished?: boolean) => void;
+    onChange: (date: Date, isFinished?: boolean) => void;
     disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;

--- a/lib/src/DatePicker/DatePicker.d.ts
+++ b/lib/src/DatePicker/DatePicker.d.ts
@@ -5,7 +5,7 @@ import { RenderDay } from './Calendar';
 import { Moment } from 'moment';
 
 export interface DatePickerProps {
-    date: object;
+    date: Moment;
     minDate?: DateType;
     maxDate?: DateType;
     onChange: (date: Moment, isFinished?: boolean) => void;

--- a/lib/src/DatePicker/DatePickerWrapper.d.ts
+++ b/lib/src/DatePicker/DatePickerWrapper.d.ts
@@ -8,7 +8,7 @@ import { Moment } from 'moment';
 export interface DatePickerWrapperProps extends ModalWrapperProps {
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: object) => void;
+    onChange: (date: Date) => void;
     autoOk?: boolean;
     disablePast?: boolean;
     disableFuture?: boolean;

--- a/lib/src/DatePicker/DatePickerWrapper.d.ts
+++ b/lib/src/DatePicker/DatePickerWrapper.d.ts
@@ -8,7 +8,7 @@ import { Moment } from 'moment';
 export interface DatePickerWrapperProps extends ModalWrapperProps {
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: Date) => void;
+    onChange: (date: Moment) => void;
     autoOk?: boolean;
     disablePast?: boolean;
     disableFuture?: boolean;

--- a/lib/src/DatePicker/DatePickerWrapper.d.ts
+++ b/lib/src/DatePicker/DatePickerWrapper.d.ts
@@ -4,17 +4,17 @@ import { Utils } from '../utils/utils';
 import { RenderDay } from './Calendar';
 import { ModalWrapperProps } from '../wrappers/ModalWrapper';
 import { Moment } from 'moment';
+import { PickerBaseProps } from '../_shared/PickerBase'
+import { Omit } from 'material-ui'
 
-export interface DatePickerWrapperProps extends ModalWrapperProps {
+export interface DatePickerWrapperProps extends PickerBaseProps,
+  Omit<ModalWrapperProps, 'onChange'> {
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: Moment) => void;
-    autoOk?: boolean;
     disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;
     openToYearSelection?: boolean;
-    returnMoment?: boolean;
     leftArrowIcon?: ReactNode;
     rightArrowIcon?: ReactNode;
     renderDay?: RenderDay;

--- a/lib/src/DatePicker/YearSelection.d.ts
+++ b/lib/src/DatePicker/YearSelection.d.ts
@@ -1,9 +1,10 @@
 import { ComponentClass, ReactNode } from 'react';
 import { DateType } from '../constants/prop-types';
 import { Utils } from '../utils/utils';
+import { Moment } from 'moment';
 
 export interface YearSelectionProps {
-    date: object;
+    date: Moment;
     minDate?: DateType;
     maxDate?: DateType;
     onChange: (date: Moment) => void;

--- a/lib/src/DatePicker/YearSelection.d.ts
+++ b/lib/src/DatePicker/YearSelection.d.ts
@@ -6,7 +6,7 @@ export interface YearSelectionProps {
     date: object;
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: object) => void;
+    onChange: (date: Date) => void;
     disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;

--- a/lib/src/DatePicker/YearSelection.d.ts
+++ b/lib/src/DatePicker/YearSelection.d.ts
@@ -6,7 +6,7 @@ export interface YearSelectionProps {
     date: object;
     minDate?: DateType;
     maxDate?: DateType;
-    onChange: (date: Date) => void;
+    onChange: (date: Moment) => void;
     disablePast?: boolean;
     disableFuture?: boolean;
     animateYearScrolling?: boolean;

--- a/lib/src/DateTimePicker/DateTimePicker.d.ts
+++ b/lib/src/DateTimePicker/DateTimePicker.d.ts
@@ -6,7 +6,7 @@ import { RenderDay } from '../DatePicker/Calendar';
 import { Moment } from 'moment';
 
 export interface DateTimePickerProps {
-  date: object;
+  date: Moment;
   minDate?: DateType;
   maxDate?: DateType;
   onChange: (date: Moment, isFinished: boolean, viewType?: DateTimePickerView) => void;

--- a/lib/src/DateTimePicker/DateTimePicker.d.ts
+++ b/lib/src/DateTimePicker/DateTimePicker.d.ts
@@ -9,7 +9,7 @@ export interface DateTimePickerProps {
   date: object;
   minDate?: DateType;
   maxDate?: DateType;
-  onChange: (date: object, isFinished?: boolean) => void;
+  onChange: (date: Date, isFinished: boolean, viewType?: DateTimePickerView) => void;
   disablePast?: boolean;
   disableFuture?: boolean;
   autoSubmit?: boolean;

--- a/lib/src/DateTimePicker/DateTimePicker.d.ts
+++ b/lib/src/DateTimePicker/DateTimePicker.d.ts
@@ -9,7 +9,7 @@ export interface DateTimePickerProps {
   date: object;
   minDate?: DateType;
   maxDate?: DateType;
-  onChange: (date: Date, isFinished: boolean, viewType?: DateTimePickerView) => void;
+  onChange: (date: Moment, isFinished: boolean, viewType?: DateTimePickerView) => void;
   disablePast?: boolean;
   disableFuture?: boolean;
   autoSubmit?: boolean;

--- a/lib/src/DateTimePicker/DateTimePickerHeader.d.ts
+++ b/lib/src/DateTimePicker/DateTimePickerHeader.d.ts
@@ -1,11 +1,12 @@
 import { ComponentClass } from 'react';
 import { DateTimePickerView } from '../constants/date-picker-view';
 import { Utils } from '../utils/utils';
+import { Moment } from 'moment';
 
 type MeridiemMode = 'am' | 'pm';
 
 export interface DateTimePickerHeaderProps {
-  date: object;
+  date: Moment;
   meridiemMode: MeridiemMode;
   openView: DateTimePickerView;
   onOpenViewChange: (view: DateTimePickerView) => void;

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
@@ -9,7 +9,7 @@ import { Moment } from 'moment';
 export interface DateTimePickerWrapperProps extends ModalWrapperProps {
   minDate?: DateType;
   maxDate?: DateType;
-  onChange: (date: object) => void;
+  onChange: (date: Date) => void;
   disablePast?: boolean;
   disableFuture?: boolean;
   autoOk?: boolean;

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
@@ -9,7 +9,7 @@ import { Moment } from 'moment';
 export interface DateTimePickerWrapperProps extends ModalWrapperProps {
   minDate?: DateType;
   maxDate?: DateType;
-  onChange: (date: Date) => void;
+  onChange: (date: Moment) => void;
   disablePast?: boolean;
   disableFuture?: boolean;
   autoOk?: boolean;
@@ -19,8 +19,8 @@ export interface DateTimePickerWrapperProps extends ModalWrapperProps {
   ampm?: boolean;
   animateYearScrolling?: boolean;
   openTo?: DateTimePickerView;
-  leftArrowIcon: ReactNode;
-  rightArrowIcon: ReactNode;
+  leftArrowIcon?: ReactNode;
+  rightArrowIcon?: ReactNode;
   dateRangeIcon?: ReactNode;
   timeIcon?: ReactNode;
   renderDay?: RenderDay;

--- a/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
+++ b/lib/src/DateTimePicker/DateTimePickerWrapper.d.ts
@@ -5,18 +5,17 @@ import { Utils } from '../utils/utils';
 import { RenderDay } from '../DatePicker/Calendar';
 import { ModalWrapperProps } from '../wrappers/ModalWrapper';
 import { Moment } from 'moment';
+import { PickerBaseProps } from '../_shared/PickerBase'
+import { Omit } from 'material-ui'
 
-export interface DateTimePickerWrapperProps extends ModalWrapperProps {
+export interface DateTimePickerWrapperProps extends PickerBaseProps,
+  Omit<ModalWrapperProps, 'onChange'> {
   minDate?: DateType;
   maxDate?: DateType;
-  onChange: (date: Moment) => void;
   disablePast?: boolean;
   disableFuture?: boolean;
-  autoOk?: boolean;
   autoSubmit?: boolean;
-  returnMoment?: boolean;
   showTabs?: boolean;
-  ampm?: boolean;
   animateYearScrolling?: boolean;
   openTo?: DateTimePickerView;
   leftArrowIcon?: ReactNode;

--- a/lib/src/TimePicker/HourView.d.ts
+++ b/lib/src/TimePicker/HourView.d.ts
@@ -3,7 +3,7 @@ import { Utils } from '../utils/utils';
 
 export interface HourViewProps {
     date: object;
-    onChange: (date: Date, isFinished?: boolean) => void;
+    onChange: (date: Moment, isFinished?: boolean) => void;
     ampm?: boolean;
     utils?: Utils;
 }

--- a/lib/src/TimePicker/HourView.d.ts
+++ b/lib/src/TimePicker/HourView.d.ts
@@ -1,8 +1,9 @@
 import { ComponentClass } from 'react';
 import { Utils } from '../utils/utils';
+import { Moment } from 'moment';
 
 export interface HourViewProps {
-    date: object;
+    date: Moment;
     onChange: (date: Moment, isFinished?: boolean) => void;
     ampm?: boolean;
     utils?: Utils;

--- a/lib/src/TimePicker/HourView.d.ts
+++ b/lib/src/TimePicker/HourView.d.ts
@@ -3,7 +3,7 @@ import { Utils } from '../utils/utils';
 
 export interface HourViewProps {
     date: object;
-    onChange: (date: object, isFinished?: boolean) => void;
+    onChange: (date: Date, isFinished?: boolean) => void;
     ampm?: boolean;
     utils?: Utils;
 }

--- a/lib/src/TimePicker/MinutesView.d.ts
+++ b/lib/src/TimePicker/MinutesView.d.ts
@@ -3,7 +3,7 @@ import { Utils } from '../utils/utils';
 
 export interface MinutesViewProps {
     date: object;
-    onChange: (date: object, isFinished?: boolean) => void;
+    onChange: (date: Date, isFinished?: boolean) => void;
     utils?: Utils;
 }
 

--- a/lib/src/TimePicker/MinutesView.d.ts
+++ b/lib/src/TimePicker/MinutesView.d.ts
@@ -3,7 +3,7 @@ import { Utils } from '../utils/utils';
 
 export interface MinutesViewProps {
     date: object;
-    onChange: (date: Date, isFinished?: boolean) => void;
+    onChange: (date: Moment, isFinished?: boolean) => void;
     utils?: Utils;
 }
 

--- a/lib/src/TimePicker/MinutesView.d.ts
+++ b/lib/src/TimePicker/MinutesView.d.ts
@@ -1,8 +1,9 @@
 import { ComponentClass } from 'react';
 import { Utils } from '../utils/utils';
+import { Moment } from 'moment';
 
 export interface MinutesViewProps {
-    date: object;
+    date: Moment;
     onChange: (date: Moment, isFinished?: boolean) => void;
     utils?: Utils;
 }

--- a/lib/src/TimePicker/TimePicker.d.ts
+++ b/lib/src/TimePicker/TimePicker.d.ts
@@ -1,8 +1,9 @@
 import { ComponentClass } from 'react';
 import { Utils } from '../utils/utils';
+import { Moment } from 'moment';
 
 export interface TimePickerProps {
-    date: object;
+    date: Moment;
     onChange: (date: Moment, isFinished?: boolean) => void;
     ampm?: boolean;
     utils?: Utils;

--- a/lib/src/TimePicker/TimePicker.d.ts
+++ b/lib/src/TimePicker/TimePicker.d.ts
@@ -3,7 +3,7 @@ import { Utils } from '../utils/utils';
 
 export interface TimePickerProps {
     date: object;
-    onChange: (date: Date, isFinished?: boolean) => void;
+    onChange: (date: Moment, isFinished?: boolean) => void;
     ampm?: boolean;
     utils?: Utils;
 }

--- a/lib/src/TimePicker/TimePicker.d.ts
+++ b/lib/src/TimePicker/TimePicker.d.ts
@@ -3,7 +3,7 @@ import { Utils } from '../utils/utils';
 
 export interface TimePickerProps {
     date: object;
-    onChange: (date: object, isFinished?: boolean) => void;
+    onChange: (date: Date, isFinished?: boolean) => void;
     ampm?: boolean;
     utils?: Utils;
 }

--- a/lib/src/TimePicker/TimePickerWrapper.d.ts
+++ b/lib/src/TimePicker/TimePickerWrapper.d.ts
@@ -1,13 +1,11 @@
 import { ComponentClass } from 'react';
 import { Utils } from '../utils/utils';
 import { ModalWrapperProps } from '../wrappers/ModalWrapper';
-import { Moment } from 'moment'
+import { PickerBaseProps } from '../_shared/PickerBase'
+import { Omit } from 'material-ui'
 
-export interface TimePickerWrapperProps extends ModalWrapperProps {
-    onChange: (date: Moment) => void;
-    autoOk?: boolean;
-    returnMoment?: boolean;
-    ampm?: boolean;
+export interface TimePickerWrapperProps extends PickerBaseProps,
+  Omit<ModalWrapperProps, 'onChange'> {
     utils?: Utils;
 }
 

--- a/lib/src/TimePicker/TimePickerWrapper.d.ts
+++ b/lib/src/TimePicker/TimePickerWrapper.d.ts
@@ -1,9 +1,10 @@
 import { ComponentClass } from 'react';
 import { Utils } from '../utils/utils';
 import { ModalWrapperProps } from '../wrappers/ModalWrapper';
+import { Moment } from 'moment'
 
 export interface TimePickerWrapperProps extends ModalWrapperProps {
-    onChange: (date: Date) => void;
+    onChange: (date: Moment) => void;
     autoOk?: boolean;
     returnMoment?: boolean;
     ampm?: boolean;

--- a/lib/src/TimePicker/TimePickerWrapper.d.ts
+++ b/lib/src/TimePicker/TimePickerWrapper.d.ts
@@ -1,10 +1,9 @@
-import { ComponentClass, ReactNode } from 'react';
-import { DateType } from '../constants/prop-types';
+import { ComponentClass } from 'react';
 import { Utils } from '../utils/utils';
 import { ModalWrapperProps } from '../wrappers/ModalWrapper';
 
 export interface TimePickerWrapperProps extends ModalWrapperProps {
-    onChange: (date: object) => void;
+    onChange: (date: Date) => void;
     autoOk?: boolean;
     returnMoment?: boolean;
     ampm?: boolean;

--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -1,21 +1,19 @@
-import { ComponentClass, ReactNode } from 'react';
-import { DateType } from '../constants/prop-types';
-import { Utils } from '../utils/utils';
+import { ComponentClass } from 'react';
+import { DateType } from '../constants/prop-types'
 import { TextFieldProps } from 'material-ui/TextField';
+import {Omit} from 'material-ui'
 
-export interface DateTextFieldProps extends TextFieldProps {
-    value: any;
+export interface DateTextFieldProps extends Omit<TextFieldProps, 'onChange' | 'value'> {
+    value: DateType;
     mask?: any;
-    onChange: (date: object) => void;
-    onClear: () => void;
-    InputProps: any;
+    onChange: (date: Date, foo: boolean) => void;
+    onClear?: () => void;
     keyboard?: boolean;
-    disabled?: boolean;
     format?: string;
     invalidLabel?: string;
     emptyLabel?: string;
-    labelFunc?: (date: object, invalidLabel: string) => string;
-    keyboardIcon?: ReactNode;
+    labelFunc?: (date: Date, invalidLabel: string) => string;
+    keyboardIcon?: string;
     invalidDateMessage?: string;
     clearable?: boolean;
 }

--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -1,7 +1,7 @@
 import { ComponentClass } from 'react';
 import { DateType } from '../constants/prop-types'
 import { TextFieldProps } from 'material-ui/TextField';
-import {Omit} from 'material-ui'
+import { Omit } from 'material-ui'
 import { Moment } from 'moment'
 
 export interface DateTextFieldProps extends Omit<TextFieldProps, 'onChange' | 'value'> {

--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -2,17 +2,18 @@ import { ComponentClass } from 'react';
 import { DateType } from '../constants/prop-types'
 import { TextFieldProps } from 'material-ui/TextField';
 import {Omit} from 'material-ui'
+import { Moment } from 'moment'
 
 export interface DateTextFieldProps extends Omit<TextFieldProps, 'onChange' | 'value'> {
     value: DateType;
     mask?: any;
-    onChange: (date: Date, foo: boolean) => void;
+    onChange: (date: Moment, foo: boolean) => void;
     onClear?: () => void;
     keyboard?: boolean;
     format?: string;
     invalidLabel?: string;
     emptyLabel?: string;
-    labelFunc?: (date: Date, invalidLabel: string) => string;
+    labelFunc?: (date: Moment, invalidLabel: string) => string;
     keyboardIcon?: string;
     invalidDateMessage?: string;
     clearable?: boolean;

--- a/lib/src/_shared/PickerBase.d.ts
+++ b/lib/src/_shared/PickerBase.d.ts
@@ -1,0 +1,8 @@
+import {Moment} from 'moment'
+
+export interface PickerBaseProps {
+  onChange: (date: Date | Moment) => void;
+  autoOk?: boolean;
+  returnMoment?: boolean;
+  ampm?: boolean;
+}

--- a/lib/src/wrappers/ModalWrapper.d.ts
+++ b/lib/src/wrappers/ModalWrapper.d.ts
@@ -1,7 +1,4 @@
 import { ComponentClass, ReactNode } from 'react';
-import { ButtonProps } from 'material-ui/Button';
-import { DateType } from '../constants/prop-types';
-import { Utils } from '../utils/utils';
 import { DateTextFieldProps } from '../_shared/DateTextField';
 
 export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
@@ -12,7 +9,6 @@ export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
     okLabel?: ReactNode;
     cancelLabel?: ReactNode;
     clearLabel?: ReactNode;
-    clearable?: boolean;
 }
 
 declare const ModalWrapper: ComponentClass<ModalWrapperProps>;

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "lib": ["es6", "dom"],
+    "sourceMap": true,
+    "jsx": "react",
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "forceConsistentCasingInFileNames": true,
+    "suppressImplicitAnyIndexErrors": true,
+    "noEmit": true,
+    "experimentalDecorators": true
+  },
+  "include": ["src/**/*", "__tests__/**/*.tsx"]
+}


### PR DESCRIPTION
- [x] I have changed my target branch to **develop** :facepunch:

## Description
When looking to use the library, some of the types were loose (e.g. `object`), there were a few redundancies (re-specifying inherited props) and I noticed there were no typescript tests.

This PR adds the demos as typescript usage tests and asserts typescript definitions with the `test` script used by CI.

/cc @alitaheri  
  