### PR TITLE
max and min date support for keyboard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,8 @@ disablePast | boolean | false | Disable past dates
 disableFuture | boolean | false | Disable future dates
 animateYearScrolling | boolean | false | Will animate year selection (note that will work for browser supports scrollIntoView api)
 openToYearSelection | boolean | false | Open datepicker from year selection
-keyboard | boolean | false | Allow keyboard input
 minDate | date | '1900-01-01' | Minimum selectable date
-minDateMessage | string | 'Invalid Date' | Minimum date error message for keyboard input
 maxDate | date | '2100-01-01' | Maximum selectable date
-maxDateMessage | string | 'Invalid Date' | Maximum date error message for keyboard input
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed
@@ -112,6 +109,8 @@ rightArrowIcon | react node, string | 'keyboard_arrow_right'| Right arrow icon
 shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable custom date in calendar
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
+minDateMessage | string | 'Invalid Date' | Minimum date error message for keyboard input
+maxDateMessage | string | 'Invalid Date' | Maximum date error message for keyboard input
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
 
@@ -147,11 +146,8 @@ disableFuture | boolean | false | Disable future dates
 showTabs | boolean | false | Show date/time tabs
 openTo | one of 'year', 'date', 'hour', 'minutes' | 'date' | Open to particular view
 animateYearScrolling | boolean | false | Will animate year selection
-keyboard | boolean | false | Allow keyboard input
 minDate | date | '1900-01-01' | Minimum selectable date
-minDateMessage | string | 'Invalid Date' | Minimum date error message for keyboard input
 maxDate | date | '2100-01-01' | Maximum selectable date
-maxDateMessage | string | 'Invalid Date' | Maximum date error message for keyboard input
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChangeg
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed
@@ -169,6 +165,8 @@ ampm | boolean | true | 12h/24h view for hour selection clock
 shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable custom date in calendar
 keyboard | boolean | false | Allow to manual input date to the text field
 keyboardIcon | react node, string | 'event' | Keyboard adornment icon
+maxDateMessage | string | 'Invalid Date' | Maximum date error message for keyboard input
+minDateMessage | string | 'Invalid Date' | Minimum date error message for keyboard input
 invalidDateMessage | string | 'Invalid Date Format' | Message, appearing when date cannot be parsed
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed

--- a/README.md
+++ b/README.md
@@ -93,8 +93,11 @@ disablePast | boolean | false | Disable past dates
 disableFuture | boolean | false | Disable future dates
 animateYearScrolling | boolean | false | Will animate year selection (note that will work for browser supports scrollIntoView api)
 openToYearSelection | boolean | false | Open datepicker from year selection
+keyboard | boolean | false | Allow keyboard input
 minDate | date | '1900-01-01' | Minimum selectable date
+minDateMessage | string | 'Invalid Date' | Minimum date error message for keyboard input
 maxDate | date | '2100-01-01' | Maximum selectable date
+maxDateMessage | string | 'Invalid Date' | Maximum date error message for keyboard input
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChange
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed
@@ -144,8 +147,11 @@ disableFuture | boolean | false | Disable future dates
 showTabs | boolean | false | Show date/time tabs
 openTo | one of 'year', 'date', 'hour', 'minutes' | 'date' | Open to particular view
 animateYearScrolling | boolean | false | Will animate year selection
+keyboard | boolean | false | Allow keyboard input
 minDate | date | '1900-01-01' | Minimum selectable date
+minDateMessage | string | 'Invalid Date' | Minimum date error message for keyboard input
 maxDate | date | '2100-01-01' | Maximum selectable date
+maxDateMessage | string | 'Invalid Date' | Maximum date error message for keyboard input
 onChange | func | required | Callback firing when date accepted
 returnMoment | boolean | true | Will return moment object in onChangeg
 invalidLabel | string | 'Unknown' | Displayed string if date cant be parsed

--- a/docs/src/Demo/Examples/BasicUsage.jsx
+++ b/docs/src/Demo/Examples/BasicUsage.jsx
@@ -6,7 +6,6 @@ import { TimePicker, DatePicker } from 'material-ui-pickers';
 export default class BasicUsage extends Component {
   state = {
     selectedDate: moment(),
-    today: new Date(),
   }
 
   handleDateChange = (date) => {
@@ -14,7 +13,7 @@ export default class BasicUsage extends Component {
   }
 
   render() {
-    const { selectedDate, today } = this.state;
+    const { selectedDate } = this.state;
 
     return (
       <Fragment>
@@ -26,7 +25,7 @@ export default class BasicUsage extends Component {
           <DatePicker
             keyboard
             clearable
-            maxDate={today}
+            disableFuture
             maxDateMessage="Date must be less than today"
             value={selectedDate}
             onChange={this.handleDateChange}

--- a/docs/src/Demo/Examples/BasicUsage.jsx
+++ b/docs/src/Demo/Examples/BasicUsage.jsx
@@ -6,6 +6,7 @@ import { TimePicker, DatePicker } from 'material-ui-pickers';
 export default class BasicUsage extends Component {
   state = {
     selectedDate: moment(),
+    today: new Date(),
   }
 
   handleDateChange = (date) => {
@@ -13,7 +14,7 @@ export default class BasicUsage extends Component {
   }
 
   render() {
-    const { selectedDate } = this.state;
+    const { selectedDate, today } = this.state;
 
     return (
       <Fragment>
@@ -25,6 +26,8 @@ export default class BasicUsage extends Component {
           <DatePicker
             keyboard
             clearable
+            maxDate={today}
+            maxDateMessage="Date must be less than today"
             value={selectedDate}
             onChange={this.handleDateChange}
             animateYearScrolling={false}

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -96,6 +96,8 @@ export default class DatePickerWrapper extends PickerBase {
         ref={this.getRef}
         value={value}
         format={format}
+        minDate={minDate}
+        maxDate={maxDate}
         onClear={this.handleClear}
         onAccept={this.handleAccept}
         onChange={this.handleTextFieldChange}

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -84,6 +84,8 @@ export default class DatePickerWrapper extends PickerBase {
       labelFunc,
       utils,
       shouldDisableDate,
+      minDateMessage,
+      maxDateMessage,
       ...other
     } = this.props;
 
@@ -98,6 +100,8 @@ export default class DatePickerWrapper extends PickerBase {
         onDismiss={this.handleDismiss}
         invalidLabel={invalidLabel}
         labelFunc={labelFunc}
+        minDateMessage={minDateMessage}
+        maxDateMessage={maxDateMessage}
         {...other}
       >
         <DatePicker

--- a/lib/src/DatePicker/DatePickerWrapper.jsx
+++ b/lib/src/DatePicker/DatePickerWrapper.jsx
@@ -73,11 +73,7 @@ export default class DatePickerWrapper extends PickerBase {
       value,
       format,
       autoOk,
-      minDate,
-      maxDate,
       onChange,
-      disablePast,
-      disableFuture,
       animateYearScrolling,
       openToYearSelection,
       returnMoment,
@@ -96,8 +92,6 @@ export default class DatePickerWrapper extends PickerBase {
         ref={this.getRef}
         value={value}
         format={format}
-        minDate={minDate}
-        maxDate={maxDate}
         onClear={this.handleClear}
         onAccept={this.handleAccept}
         onChange={this.handleTextFieldChange}
@@ -109,12 +103,8 @@ export default class DatePickerWrapper extends PickerBase {
         <DatePicker
           date={date}
           onChange={this.handleChange}
-          disablePast={disablePast}
-          disableFuture={disableFuture}
           animateYearScrolling={animateYearScrolling}
           openToYearSelection={openToYearSelection}
-          minDate={minDate}
-          maxDate={maxDate}
           leftArrowIcon={leftArrowIcon}
           rightArrowIcon={rightArrowIcon}
           renderDay={renderDay}

--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -6,6 +6,8 @@ import { TextFieldProps } from 'material-ui/TextField';
 export interface DateTextFieldProps extends TextFieldProps {
     minDate?: DateType;
     minDateMessage?: string;
+    disablePast?: boolean;
+    disableFuture?: boolean;
     maxDate?: DateType;
     maxDateMessage?: string;
     value: any;

--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -4,6 +4,10 @@ import { Utils } from '../utils/utils';
 import { TextFieldProps } from 'material-ui/TextField';
 
 export interface DateTextFieldProps extends TextFieldProps {
+    minDate?: DateType;
+    minDateMessage?: string;
+    maxDate?: DateType;
+    maxDateMessage?: string;
     value: any;
     mask?: any;
     onChange: (date: object) => void;

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import moment from 'moment';
 import { TextField, InputAdornment, IconButton, Icon } from 'material-ui';
 
+import DomainPropTypes from '../constants/prop-types';
 import MaskedInput from './MaskedInput';
 
 
@@ -17,6 +18,10 @@ export default class DateTextField extends PureComponent {
       PropTypes.instanceOf(Date),
     ]),
     mask: PropTypes.any,
+    minDate: DomainPropTypes.date,
+    minDateMessage: PropTypes.string,
+    maxDate: DomainPropTypes.date,
+    maxDateMessage: PropTypes.string,
     disabled: PropTypes.bool,
     format: PropTypes.string,
     onChange: PropTypes.func.isRequired,
@@ -46,6 +51,10 @@ export default class DateTextField extends PureComponent {
     invalidDateMessage: 'Invalid Date Format',
     clearable: false,
     onClear: undefined,
+    minDate: undefined,
+    maxDate: undefined,
+    minDateMessage: undefined,
+    maxDateMessage: undefined,
   }
 
   getDisplayDate = (props) => {
@@ -87,6 +96,32 @@ export default class DateTextField extends PureComponent {
     }
   }
 
+  getError = (value) => {
+    const {
+      maxDate,
+      minDate,
+      maxDateMessage,
+      minDateMessage,
+      invalidDateMessage,
+    } = this.props;
+
+    const getDate = date => moment(date).toDate();
+
+    if (!value.isValid()) {
+      return invalidDateMessage;
+    }
+
+    if (maxDate && value.isAfter(getDate(maxDate))) {
+      return maxDateMessage || 'Invalid Date';
+    }
+
+    if (minDate && value.isBefore(getDate(minDate))) {
+      return minDateMessage || 'Invalid Date';
+    }
+
+    return '';
+  }
+
   handleBlur = (e) => {
     e.preventDefault();
     e.stopPropagation();
@@ -95,7 +130,6 @@ export default class DateTextField extends PureComponent {
   handleChange = (e) => {
     const {
       format,
-      invalidDateMessage,
       clearable,
       onClear,
     } = this.props;
@@ -112,7 +146,7 @@ export default class DateTextField extends PureComponent {
 
     const oldValue = moment(this.state.value);
     const newValue = moment(e.target.value, format, true);
-    const error = newValue.isValid() ? '' : invalidDateMessage;
+    const error = this.getError(newValue);
 
     this.setState({
       displayValue: e.target.value,
@@ -169,6 +203,10 @@ export default class DateTextField extends PureComponent {
       mask,
       InputProps,
       keyboardIcon,
+      maxDate,
+      minDate,
+      maxDateMessage,
+      minDateMessage,
       ...other
     } = this.props;
     const { displayValue, error } = this.state;

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -22,6 +22,8 @@ export default class DateTextField extends PureComponent {
     minDateMessage: PropTypes.string,
     maxDate: DomainPropTypes.date,
     maxDateMessage: PropTypes.string,
+    disablePast: PropTypes.bool,
+    disableFuture: PropTypes.bool,
     disabled: PropTypes.bool,
     format: PropTypes.string,
     onChange: PropTypes.func.isRequired,
@@ -51,10 +53,12 @@ export default class DateTextField extends PureComponent {
     invalidDateMessage: 'Invalid Date Format',
     clearable: false,
     onClear: undefined,
-    minDate: undefined,
-    maxDate: undefined,
-    minDateMessage: undefined,
-    maxDateMessage: undefined,
+    disablePast: false,
+    disableFuture: false,
+    minDate: '1900-01-01',
+    maxDate: '2100-01-01',
+    minDateMessage: 'Invalid Date',
+    maxDateMessage: 'Invalid Date',
   }
 
   getDisplayDate = (props) => {
@@ -100,6 +104,8 @@ export default class DateTextField extends PureComponent {
     const {
       maxDate,
       minDate,
+      disablePast,
+      disableFuture,
       maxDateMessage,
       minDateMessage,
       invalidDateMessage,
@@ -111,12 +117,18 @@ export default class DateTextField extends PureComponent {
       return invalidDateMessage;
     }
 
-    if (maxDate && value.isAfter(getDate(maxDate))) {
-      return maxDateMessage || 'Invalid Date';
+    if (
+      (maxDate && value.isAfter(getDate(maxDate))) ||
+      (disableFuture && value.isAfter(moment(), 'day'))
+    ) {
+      return maxDateMessage;
     }
 
-    if (minDate && value.isBefore(getDate(minDate))) {
-      return minDateMessage || 'Invalid Date';
+    if (
+      (minDate && value.isBefore(getDate(minDate))) ||
+      (disablePast && value.isBefore(moment(), 'day'))
+    ) {
+      return minDateMessage;
     }
 
     return '';
@@ -205,6 +217,8 @@ export default class DateTextField extends PureComponent {
       keyboardIcon,
       maxDate,
       minDate,
+      disablePast,
+      disableFuture,
       maxDateMessage,
       minDateMessage,
       ...other


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have passed maxDate, minDate, disablePass, disableFuture to DateTextField 
- [x] I have added error message method to DateTextField
- [x] I have added example in docs
- [x] I have added new params to README.md
- [x] I have changed target ti develop


# <!-- Please refer issue number here, if exists -->

## Description

Now if keyboard input are allowed becomes possible set not valid date to picker. PR to fix this