### PR TITLE
Change keyboardIcon type from string to ReactNode.

### DIFF
--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -1,4 +1,4 @@
-import { ComponentClass } from 'react';
+import { ComponentClass, ReactNode } from 'react';
 import { DateType } from '../constants/prop-types'
 import { TextFieldProps } from 'material-ui/TextField';
 import { Omit } from 'material-ui'
@@ -20,7 +20,7 @@ export interface DateTextFieldProps extends Omit<TextFieldProps, 'onChange' | 'v
     invalidLabel?: string;
     emptyLabel?: string;
     labelFunc?: (date: Moment, invalidLabel: string) => string;
-    keyboardIcon?: string;
+    keyboardIcon?: ReactNode;
     invalidDateMessage?: string;
     clearable?: boolean;
 }


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x ] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
I noticed that TypeScript complained about using an icon for keyboardIcon due to the type being a string. I changed that to a ReactNode. This is my first pull request ever on github. I hope everything is as it should be.