### PR TITLE
do not show error when value is null

### DIFF
--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -99,7 +99,12 @@ class DateTextField extends PureComponent {
     } = this.props;
 
     if (!value.isValid()) {
-      return invalidDateMessage;
+      // if null - do not show error
+      if (value.parsingFlags().nullInput) {
+        return '';
+      } else {
+        return invalidDateMessage;
+      }
     }
 
     if (

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -102,9 +102,8 @@ class DateTextField extends PureComponent {
       // if null - do not show error
       if (value.parsingFlags().nullInput) {
         return '';
-      } else {
-        return invalidDateMessage;
       }
+      return invalidDateMessage;
     }
 
     if (


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
Closes #198
`null` value should show empty input with no error. It's used for showing empty input or in case of clearing action.