### PR TITLE
Upgrade to material-ui@beta.31

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
-leftArrowIcon | react node | `<Icon>keyboard_arrow_left</Icoln>` Left arrow icon
+leftArrowIcon | react node | `<Icon>keyboard_arrow_left</Icon>`| Left arrow icon
 rightArrowIcon | react node | `<Icon>keyboard_arrow_right</Icon>`| Right arrow icon
 shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable custom date in calendar
 keyboard | boolean | false | Allow to manual input date to the text field
@@ -159,7 +159,7 @@ cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
-leftArrowIcon | react node | `<Icon>keyboard_arrow_left</Icoln>` Left arrow icon
+leftArrowIcon | react node | `<Icon>keyboard_arrow_left</Icon>`| Left arrow icon
 rightArrowIcon | react node | `<Icon>keyboard_arrow_right</Icon>`| Right arrow icon
 dateRangeIcon | react node | `<Icon>date_range</Icon>`| Date tab icon 
 timeIcon | react node | `<Icon>access_time</Icon>`| Time tab icon

--- a/README.md
+++ b/README.md
@@ -104,11 +104,11 @@ cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
-leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
-rightArrowIcon | react node, string | 'keyboard_arrow_right'| Right arrow icon
+leftArrowIcon | react node | `<Icon>keyboard_arrow_left</Icoln>` Left arrow icon
+rightArrowIcon | react node | `<Icon>keyboard_arrow_right</Icon>`| Right arrow icon
 shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable custom date in calendar
 keyboard | boolean | false | Allow to manual input date to the text field
-keyboardIcon | react node, string | 'event' | Keyboard adornment icon
+keyboardIcon | react node | `<Icon>event</Icon>` | Keyboard adornment icon
 maxDateMessage | string | 'Date should not be after maximal date' | Maximum date error message for keyboard input
 minDateMessage | string | 'Date should not be before minimal date' | Minimum date error message for keyboard input
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
@@ -131,7 +131,7 @@ clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 ampm | boolean | true | 12h/24h view for hour selection clock
 keyboard | boolean | false | Allow to manual input date to the text field
-keyboardIcon | react node, string | 'event' | Keyboard adornment icon
+keyboardIcon | react node | `<Icon>event</Icon>` | Keyboard adornment icon
 mask | text mask (read more [here](https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme)) | undefined | Text mask
 clearable | boolean | false | If `true`, clear button will be displayed
 TextFieldComponent | func, string | undefined | Component that should replace the default Material-UI TextField
@@ -159,14 +159,14 @@ cancelLabel | string | 'Cancel' | The label for the cancel button
 clearLabel | string | 'Clear' | The label for the clear button
 labelFunc | func | null | Allow to specify dynamic label for text field `labelFunc(date, invalidLabel)`. Note, that `date` equals `null` after picker is cleared.
 renderDay | func | null | Allow to specify custom renderer for day `renderDay(date, selectedDate, dayInCurrentMonth)`
-leftArrowIcon | react node, string | 'keyboard_arrow_left'| Left arrow icon
-rightArrowIcon | react node, string | 'keyboard_arrow_right'| Right arrow icon
-dateRangeIcon | react node, string | 'date_range'| Date tab icon 
-timeIcon | react node, string | 'access_time'| Time tab icon
+leftArrowIcon | react node | `<Icon>keyboard_arrow_left</Icoln>` Left arrow icon
+rightArrowIcon | react node | `<Icon>keyboard_arrow_right</Icon>`| Right arrow icon
+dateRangeIcon | react node | `<Icon>date_range</Icon>`| Date tab icon 
+timeIcon | react node | `<Icon>access_time</Icon>`| Time tab icon
 ampm | boolean | true | 12h/24h view for hour selection clock
 shouldDisableDate | (date: Moment) => boolean | () => false | Allow to disable custom date in calendar
 keyboard | boolean | false | Allow to manual input date to the text field
-keyboardIcon | react node, string | 'event' | Keyboard adornment icon
+keyboardIcon | react node | `<Icon>event</Icon>` | Keyboard adornment icon
 maxDateMessage | string | 'Date should not be after maximal date' | Maximum date error message for keyboard input
 minDateMessage | string | 'Date should not be before minimal date' | Minimum date error message for keyboard input
 invalidDateMessage | string | 'Invalid Date Format' | Message, appearing when date cannot be parsed

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -10,16 +10,16 @@
       "integrity": "sha512-n7MUYCO/Wt4d6Yj0ZewXSSkqBcrdLFgpQ4mUBRXBWDmLfXtgT3tJ26GVPr8HiyRLLze6iQfaBJTlvjRTjgZpRg=="
     },
     "@types/react": {
-      "version": "16.0.34",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.34.tgz",
-      "integrity": "sha512-Ee66fX2qMsDnDq7sPnDtq1bGoo479j6Fo1BlSnne+L5rp6ndzBUgz72+MRNuN56zg9uuteRCkJAMdDJEX2Uqig=="
+      "version": "16.0.35",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-16.0.35.tgz",
+      "integrity": "sha512-8MP/F4EHnNaJGJO0ExCkO2RVAkpOTIO/ByE8dbZ2LMShYZ6rGRvxKk6hVHYop54tM/BocXGVxpw+G6b8AQwy7g=="
     },
     "@types/react-transition-group": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.6.tgz",
       "integrity": "sha512-mVhRv+d0MIoLWl6hEFA7Nnd/obW2RQpZViTAKhM37mltuTDWCdoj8xAZv94ntB8wgAc6DDiDCXxFXPgClGnsfQ==",
       "requires": {
-        "@types/react": "16.0.34"
+        "@types/react": "16.0.35"
       }
     },
     "abab": {
@@ -2496,9 +2496,9 @@
       }
     },
     "dom-helpers": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.2.1.tgz",
-      "integrity": "sha1-MgPgf+0he9H0JLAZc1WC/Deyglo="
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -6264,9 +6264,9 @@
       "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
     },
     "material-ui": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.30.tgz",
-      "integrity": "sha512-cgUUYf+sXjkUQmImjngHPmwo6kBIfvZKrNxmp56cpATYyaeoBydfERwv9SfUu1zzJyXLhJ6tt17XeUBn8aSqug==",
+      "version": "1.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.31.tgz",
+      "integrity": "sha512-FTeNaBiTPhRAXMjtFyQfjKL5famLoFJK4jZS2qnkqvvbuO3LAtrdtB8L6nDzwbaU/NJmU5007gd+mjXABgBpiA==",
       "requires": {
         "@types/jss": "9.3.0",
         "@types/react-transition-group": "2.0.6",
@@ -6274,7 +6274,7 @@
         "brcast": "3.0.1",
         "classnames": "2.2.5",
         "deepmerge": "2.0.1",
-        "dom-helpers": "3.2.1",
+        "dom-helpers": "3.3.1",
         "hoist-non-react-statics": "2.3.1",
         "jss": "9.4.0",
         "jss-camel-case": "6.0.0",
@@ -6287,9 +6287,9 @@
         "lodash": "4.17.4",
         "normalize-scroll-left": "0.1.2",
         "prop-types": "15.6.0",
-        "react-event-listener": "0.5.1",
+        "react-event-listener": "0.5.3",
         "react-jss": "8.2.0",
-        "react-popper": "0.7.4",
+        "react-popper": "0.7.5",
         "react-scrollbar-size": "2.0.2",
         "react-transition-group": "2.2.1",
         "recompose": "0.26.0",
@@ -8554,9 +8554,9 @@
       "integrity": "sha512-XzgvowFrwDo6TWcpJ/WTiarb9UI6lhA4PMzS7n1joK3sHfBBBOQHUc0U4u57D6DWO9vHv6lVSWx2Q/Ymfyv4hw=="
     },
     "react-event-listener": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.1.tgz",
-      "integrity": "sha1-ujYHbke8N8Wmf/XM1Kn/DxViEEA=",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.5.3.tgz",
+      "integrity": "sha512-fTGYvhe7eTsqq0m664Km0rxKQcqLIGZWZINmy1LU0fu312tay8Mt3Twq2P5Xj1dfDVvvzT1Ql3/FDkiMPJ1MOg==",
       "requires": {
         "babel-runtime": "6.26.0",
         "fbjs": "0.8.16",
@@ -8587,9 +8587,9 @@
       }
     },
     "react-popper": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.4.tgz",
-      "integrity": "sha512-dx1fcKYYkidq7f71I1g+YX7g3QBLZ9taqiSRdJ7wbP7v/o7F6JsrUaNWGbVNul+TqdDDIZ5/k0xPUol9baqQJQ==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.7.5.tgz",
+      "integrity": "sha512-ya9dhhGCf74JTOB2uyksEHhIGw7w9tNZRUJF73lEq2h4H5JT6MBa4PdT4G+sx6fZwq+xKZAL/sVNAIuojPn7Dg==",
       "requires": {
         "popper.js": "1.12.9",
         "prop-types": "15.6.0"
@@ -9567,7 +9567,7 @@
       "requires": {
         "babel-runtime": "6.26.0",
         "prop-types": "15.6.0",
-        "react-event-listener": "0.5.1"
+        "react-event-listener": "0.5.3"
       }
     },
     "react-transition-group": {
@@ -9577,7 +9577,7 @@
       "requires": {
         "chain-function": "1.0.0",
         "classnames": "2.2.5",
-        "dom-helpers": "3.2.1",
+        "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
         "prop-types": "15.6.0",
         "warning": "3.0.0"

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,7 +8,7 @@
     "jss": "^9.4.0",
     "jss-preset-default": "^4.0.1",
     "jss-rtl": "^0.2.1",
-    "material-ui": "^1.0.0-beta.30",
+    "material-ui": "^1.0.0-beta.31",
     "material-ui-pickers-jalali-utils": "^0.2.0",
     "moment": "^2.20.1",
     "moment-jalaali": "^0.7.2",

--- a/docs/src/Demo/Demo.jsx
+++ b/docs/src/Demo/Demo.jsx
@@ -1,6 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { AppBar, Toolbar, IconButton, Typography, withStyles, Button, Tooltip } from 'material-ui';
+import { AppBar, Toolbar, IconButton, Icon, Typography, withStyles, Button, Tooltip } from 'material-ui';
 
 import Github from './components/GithubIcon';
 import SourcablePanel from './components/SourcablePanel';
@@ -36,26 +36,26 @@ class Demo extends Component {
         <AppBar position="fixed" className={classes.noShadow}>
           <Toolbar>
             <IconButton className={classes.menuButton} color="inherit" aria-label="Menu">
-              menu
+              <Icon>menu</Icon>
             </IconButton>
 
             <div className={classes.flex} />
 
             <Tooltip title="Toggle English/French moment locale" enterDelay={300}>
               <IconButton color="inherit" onClick={toggleFrench}>
-                language
+                <Icon>language</Icon>
               </IconButton>
             </Tooltip>
 
             <Tooltip title="Toggle light/dark theme" enterDelay={300}>
               <IconButton color="inherit" onClick={toggleThemeType}>
-                lightbulb_outline
+                <Icon>lightbulb_outline</Icon>
               </IconButton>
             </Tooltip>
 
             <Tooltip title="Toggle direction" enterDelay={300}>
               <IconButton color="inherit" onClick={toggleDirection}>
-                format_textdirection_l_to_r
+                <Icon>format_textdirection_l_to_r</Icon>
               </IconButton>
             </Tooltip>
             <Tooltip title="Github" enterDelay={300}>

--- a/docs/src/Demo/Examples/DateTimePickers.jsx
+++ b/docs/src/Demo/Examples/DateTimePickers.jsx
@@ -49,12 +49,12 @@ export default class BasicUsage extends Component {
             leftArrowIcon={<Icon> add_alarm </Icon>}
             rightArrowIcon={<Icon> snooze </Icon>}
             InputProps={{
-            endAdornment: (
-              <InputAdornment position="end">
-                <IconButton>
-                  <Icon>add_alarm</Icon>
-                </IconButton>
-              </InputAdornment>
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton>
+                    <Icon>add_alarm</Icon>
+                  </IconButton>
+                </InputAdornment>
             ),
           }}
           />

--- a/docs/src/Demo/Examples/DateTimePickers.jsx
+++ b/docs/src/Demo/Examples/DateTimePickers.jsx
@@ -51,7 +51,9 @@ export default class BasicUsage extends Component {
             InputProps={{
             endAdornment: (
               <InputAdornment position="end">
-                <IconButton>  add_alarm  </IconButton>
+                <IconButton>
+                  <Icon>add_alarm</Icon>
+                </IconButton>
               </InputAdornment>
             ),
           }}

--- a/docs/src/Demo/components/SourcablePanel.jsx
+++ b/docs/src/Demo/components/SourcablePanel.jsx
@@ -2,7 +2,7 @@ import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
 
 import Collapse from 'material-ui/transitions/Collapse';
-import { Typography, IconButton, withStyles } from 'material-ui';
+import { Typography, IconButton, Icon, withStyles } from 'material-ui';
 import Code from '../components/Code';
 
 class SourcablePanel extends PureComponent {
@@ -58,7 +58,7 @@ class SourcablePanel extends PureComponent {
           className={classes.sourceBtn}
           onClick={this.toggleSource}
         >
-          code
+          <Icon>code</Icon>
         </IconButton>
         { this.props.children }
       </div>,

--- a/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
+++ b/lib/__tests__/DateTimePicker/DateTimePickerWrapper.usage.tsx
@@ -48,7 +48,7 @@ export default class BasicUsage extends Component<{}, {selectedDate: Date}> {
           InputProps={{
             endAdornment: (
               <InputAdornment position="end">
-                <IconButton>  add_alarm  </IconButton>
+                <IconButton><Icon>add_alarm</Icon></IconButton>
               </InputAdornment>
             ),
           }}

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -5598,9 +5598,9 @@
       }
     },
     "jss": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/jss/-/jss-9.5.1.tgz",
-      "integrity": "sha512-py//ogG1xeztpEDmosJtrkfUXibx3qiAr+1GQvfLHp7azpqkzTPLCnainDgH7Zn0q6S7rcM1eINrVT9n/r5f2w==",
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/jss/-/jss-9.6.0.tgz",
+      "integrity": "sha512-fnj0UV//VdgxwH0h9pOZljAwFlJMZTAeaDD6u9G0VFMSDwTgdRYxV7+/RZohZYMEVITkgXedHiQHW5ETRVAXkA==",
       "dev": true,
       "requires": {
         "is-in-browser": "1.1.3",
@@ -6149,9 +6149,9 @@
       "dev": true
     },
     "material-ui": {
-      "version": "1.0.0-beta.30",
-      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.30.tgz",
-      "integrity": "sha512-cgUUYf+sXjkUQmImjngHPmwo6kBIfvZKrNxmp56cpATYyaeoBydfERwv9SfUu1zzJyXLhJ6tt17XeUBn8aSqug==",
+      "version": "1.0.0-beta.31",
+      "resolved": "https://registry.npmjs.org/material-ui/-/material-ui-1.0.0-beta.31.tgz",
+      "integrity": "sha512-FTeNaBiTPhRAXMjtFyQfjKL5famLoFJK4jZS2qnkqvvbuO3LAtrdtB8L6nDzwbaU/NJmU5007gd+mjXABgBpiA==",
       "dev": true,
       "requires": {
         "@types/jss": "9.3.0",
@@ -6162,7 +6162,7 @@
         "deepmerge": "2.0.1",
         "dom-helpers": "3.3.1",
         "hoist-non-react-statics": "2.3.1",
-        "jss": "9.5.1",
+        "jss": "9.6.0",
         "jss-camel-case": "6.0.0",
         "jss-default-unit": "8.0.2",
         "jss-global": "3.0.0",
@@ -7340,7 +7340,7 @@
       "dev": true,
       "requires": {
         "hoist-non-react-statics": "2.3.1",
-        "jss": "9.5.1",
+        "jss": "9.6.0",
         "jss-preset-default": "4.1.0",
         "prop-types": "15.6.0",
         "theming": "1.3.0"

--- a/lib/package.json
+++ b/lib/package.json
@@ -89,7 +89,7 @@
     "fs-extra": "^4.0.2",
     "glob": "^7.1.2",
     "jest": "^21.2.1",
-    "material-ui": "^1.0.0-beta.30",
+    "material-ui": "^1.0.0-beta.31",
     "moment": "^2.19.2",
     "np": "^2.18.3",
     "prop-types": "^15.6.0",

--- a/lib/package.json
+++ b/lib/package.json
@@ -33,7 +33,7 @@
   },
   "peerDependencies": {
     "classnames": "^2.2.5",
-    "material-ui": "^1.0.0-beta.30",
+    "material-ui": "^1.0.0-beta.31",
     "moment": "^2.19.2",
     "prop-types": "^15.6.0",
     "react": "^16.2.0",

--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -34,7 +34,7 @@ export const CalendarHeader = (props) => {
         </Typography>
 
         <IconButton onClick={selectNextMonth}>
-            <Icon>{rtl ? leftArrowIcon : rightArrowIcon}</Icon>
+          <Icon>{rtl ? leftArrowIcon : rightArrowIcon}</Icon>
         </IconButton>
       </div>
 

--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import withStyles from 'material-ui/styles/withStyles';
 import Typography from 'material-ui/Typography';
 import IconButton from 'material-ui/IconButton';
+import Icon from 'material-ui/Icon';
 import * as defaultUtils from '../utils/utils';
 
 export const CalendarHeader = (props) => {
@@ -25,7 +26,7 @@ export const CalendarHeader = (props) => {
     <div>
       <div className={classes.switchHeader}>
         <IconButton onClick={selectPreviousMonth}>
-          {rtl ? rightArrowIcon : leftArrowIcon}
+          <Icon>{rtl ? rightArrowIcon : leftArrowIcon}</Icon>
         </IconButton>
 
         <Typography type="body1">
@@ -33,7 +34,7 @@ export const CalendarHeader = (props) => {
         </Typography>
 
         <IconButton onClick={selectNextMonth}>
-          {rtl ? leftArrowIcon : rightArrowIcon}
+            <Icon>{rtl ? leftArrowIcon : rightArrowIcon}</Icon>
         </IconButton>
       </div>
 

--- a/lib/src/DateTimePicker/DateTimePickerTabs.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerTabs.jsx
@@ -5,6 +5,7 @@ import withTheme from 'material-ui/styles/withTheme';
 import Paper from 'material-ui/Paper';
 import Tabs from 'material-ui/Tabs';
 import Tab from 'material-ui/Tabs/Tab';
+import Icon from 'material-ui/Icon';
 import * as viewType from '../constants/date-picker-view';
 
 const viewToTabIndex = (openView) => {
@@ -49,8 +50,8 @@ export const DateTimePickerTabs = (props) => {
         className={classes.tabs}
         indicatorColor={indicatorColor}
       >
-        <Tab value="date" icon={dateRangeIcon} />
-        <Tab value="time" icon={timeIcon} />
+        <Tab value="date" icon={<Icon>{dateRangeIcon}</Icon>} />
+        <Tab value="time" icon={<Icon>{timeIcon}</Icon>} />
       </Tabs>
     </Paper>
   );

--- a/lib/src/_shared/MaskedInput.jsx
+++ b/lib/src/_shared/MaskedInput.jsx
@@ -5,6 +5,7 @@ import MaskedInput from 'react-text-mask';
 export default class Input extends PureComponent {
   static propTypes = {
     mask: PropTypes.any,
+    inputRef: PropTypes.func.isRequired,
   }
 
   static defaultProps = {

--- a/lib/src/_shared/MaskedInput.jsx
+++ b/lib/src/_shared/MaskedInput.jsx
@@ -12,10 +12,11 @@ export default class Input extends PureComponent {
   }
 
   render() {
+    const { inputRef, ...props } = this.props;
     return (
       this.props.mask
-        ? <MaskedInput {...this.props} />
-        : <input {...this.props} />
+        ? <MaskedInput {...props} ref={inputRef} />
+        : <input {...props} ref={inputRef} />
     );
   }
 }


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
- upgraded to material-ui@beta.31
- updated docs

## Breaking changes:
`leftArrowIcon`, `rightArrowIcon`, `dateRangeIcon`, `timeIcon` and `keyboardIcon` now do not support string type:

```diff
+import Icon from 'material-ui/Icon';

<DatePicker
-   leftArrowIcon="keyboard_arrow_left"
-   rightArrowIcon="keyboard_arrow_right "
+   leftArrowIcon={<Icon> keyboard_arrow_left </Icon>}
+   rightArrowIcon={<Icon> keyboard_arrow_right </Icon>}
/>
```