### PR TITLE
Rerun validation when maxDate or minDate props is changed

### DIFF
--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -87,7 +87,7 @@ class DateTextField extends PureComponent {
       : invalidLabel;
   }
 
-  getError = (value) => {
+  getError = (value, props = this.props) => {
     const {
       maxDate,
       minDate,
@@ -96,7 +96,7 @@ class DateTextField extends PureComponent {
       maxDateMessage,
       minDateMessage,
       invalidDateMessage,
-    } = this.props;
+    } = props;
 
     if (!value.isValid()) {
       // if null - do not show error
@@ -126,7 +126,7 @@ class DateTextField extends PureComponent {
   updateState = (props = this.props) => ({
     value: props.value,
     displayValue: this.getDisplayDate(props),
-    error: this.getError(moment(props.value)),
+    error: this.getError(moment(props.value), props),
   })
 
   state = this.updateState()
@@ -134,7 +134,9 @@ class DateTextField extends PureComponent {
   componentWillReceiveProps(nextProps) {
     if (
       nextProps.value !== this.state.value ||
-      nextProps.format !== this.props.format
+      nextProps.format !== this.props.format ||
+      nextProps.maxDate !== this.props.maxDate ||
+      nextProps.minDate !== this.props.minDate
     ) {
       this.setState(this.updateState(nextProps));
     }


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
The problem is that when maxDate or minDate contains expression that can be changed independently from datepicker value, validation is not re-run and error message isn't show/hide.