### PR TITLE
remove hardcoded width for DateTimePicker's Toolbar date header

### DIFF
--- a/lib/src/DateTimePicker/DateTimePickerHeader.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerHeader.jsx
@@ -108,6 +108,7 @@ const styles = () => ({
     alignItems: 'center',
     paddingLeft: 16,
     paddingRight: 16,
+    justifyContent: 'space-around',
   },
   separator: {
     margin: '0 4px 0 2px',
@@ -132,7 +133,6 @@ const styles = () => ({
     flexDirection: 'row-reverse',
   },
   dateHeader: {
-    width: '42%',
     height: 65,
   },
   timeHeader: {


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->
Closes #153 
## Description
