### PR TITLE
Add name option to withStyles() decorator

### DIFF
--- a/lib/src/DatePicker/Day.jsx
+++ b/lib/src/DatePicker/Day.jsx
@@ -73,4 +73,4 @@ const styles = theme => ({
   },
 });
 
-export default withStyles(styles)(Day);
+export default withStyles(styles, { name: 'MuiPickersDay' })(Day);

--- a/lib/src/DatePicker/Year.jsx
+++ b/lib/src/DatePicker/Year.jsx
@@ -72,4 +72,4 @@ const styles = theme => ({
   },
 });
 
-export default withStyles(styles)(Year);
+export default withStyles(styles, { name: 'MuiPickersYear' })(Year);


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->
Resolves #256 
## Description
Added `name` option to `withStyles()` decorator for `Day` and `Year` components to improve possibility of overriding default component styles.
