### PR TITLE
Fix moment-utils startOfDay, endOfDay

### DIFF
--- a/lib/src/utils/moment-utils.js
+++ b/lib/src/utils/moment-utils.js
@@ -40,11 +40,11 @@ export default class MomentUtils {
   }
 
   static startOfDay(date) {
-    return date.startOf('day');
+    return date.clone().startOf('day');
   }
 
   static endOfDay(date) {
-    return date.endOf('day');
+    return date.clone().endOf('day');
   }
 
   static format(date, formatString) {


### PR DESCRIPTION
<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

 <!-- Please refer issue number here, if exists -->
#260 

## Description
The two methods in moment-utils invoke moment().startOf and
moment().endOf which mutate the original value. The call to clone() has
to be added in order to prevent that.
