### PR TITLE
Fix DialogActions align when clearable is set to true in IE11

### DIFF
--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -21,6 +21,7 @@ const styles = {
   },
   dialogActions: {
     // set justifyContent to default value to fix IE11 layout bug
+    // see https://github.com/dmtrKovalenko/material-ui-pickers/pull/267
     justifyContent: 'flex-start',
   },
   dialogAction: {

--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -20,6 +20,10 @@ const styles = {
     },
   },
   dialogActions: {
+    // set justifyContent to default value to fix IE11 layout bug
+    justifyContent: 'flex-start',
+  },
+  dialogAction: {
     '&:first-child': {
       marginRight: 'auto',
     },
@@ -46,7 +50,8 @@ const ModalDialog = ({
 
     <DialogActions
       classes={{
-        action: clearable && classes.dialogActions,
+        root: clearable && classes.dialogActions,
+        action: clearable && classes.dialogAction,
       }}
     >
 


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
- [x] I have changed my target branch to **develop** :facepunch:

# <!-- Please refer issue number here, if exists -->

## Description
When `clearable` is set to true, third button appears in `DialogActions` container.
First one is aligned to left side by setting `margin-right` to `auto`. Turns out, this doesn't work in IE11 and looks like this:
![mui-pic](https://user-images.githubusercontent.com/13808724/37211876-afb1b916-23ad-11e8-972c-64a5dbce5b10.png)


In this PR I'm setting `DialogActions`' container `justifyContent` property to default value (`flex-start`) due to [IE bug](https://stackoverflow.com/a/37535548).
This completely solves described issue.