### PR TITLE
Utils localization

### DIFF
--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { MuiThemeProvider, createMuiTheme } from 'material-ui';
 
-import dateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
+import Utils from 'material-ui-pickers/utils/date-fns-utils';
 import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
 
 import { create } from 'jss';
@@ -12,10 +12,15 @@ import createGenerateClassName from 'material-ui/styles/createGenerateClassName'
 import frLocale from 'date-fns/locale/fr';
 import enLocale from 'date-fns/locale/en-US';
 
-// import Demo from './Demo/Demo';
 import { setPrismTheme } from './utils/prism';
 import Layout from './layout/Layout';
 import Routes from './Routes/Routes';
+
+// /* eslint-disable import/first */
+// import moment from 'moment';
+// import 'moment/locale/fr';
+
+// moment.locale('fr');
 
 const jss = create({ plugins: [...preset().plugins, rtl()] });
 jss.options.createGenerateClassName = createGenerateClassName;
@@ -43,7 +48,6 @@ export default class App extends Component {
     const direction = this.state.direction === 'ltr' ? 'rtl' : 'ltr';
 
     document.body.dir = direction;
-
     this.setState({ direction });
   }
 
@@ -66,7 +70,10 @@ export default class App extends Component {
     return (
       <JssProvider jss={jss}>
         <MuiThemeProvider theme={this.getMuiTheme()}>
-          <MuiPickersUtilsProvider utils={dateFnsUtils} locale={this.state.localeObj}>
+          <MuiPickersUtilsProvider
+            utils={Utils}
+            locale={this.state.localeObj}
+          >
             <Layout
               toggleDirection={this.toggleDirection}
               toggleThemeType={this.toggleThemeType}

--- a/docs/src/App.js
+++ b/docs/src/App.js
@@ -1,5 +1,4 @@
 import React, { Component } from 'react';
-import PropTypes from 'prop-types';
 import { MuiThemeProvider, createMuiTheme } from 'material-ui';
 
 import dateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
@@ -10,6 +9,8 @@ import preset from 'jss-preset-default';
 import rtl from 'jss-rtl';
 import JssProvider from 'react-jss/lib/JssProvider';
 import createGenerateClassName from 'material-ui/styles/createGenerateClassName';
+import frLocale from 'date-fns/locale/fr';
+import enLocale from 'date-fns/locale/en-US';
 
 // import Demo from './Demo/Demo';
 import { setPrismTheme } from './utils/prism';
@@ -20,13 +21,11 @@ const jss = create({ plugins: [...preset().plugins, rtl()] });
 jss.options.createGenerateClassName = createGenerateClassName;
 
 export default class App extends Component {
-  static propTypes = {
-    toggleFrench: PropTypes.func.isRequired,
-  }
-
   state = {
     type: 'light',
     direction: 'ltr',
+    locale: 'en',
+    localeObj: enLocale,
   }
 
   componentWillMount = () => {
@@ -55,15 +54,23 @@ export default class App extends Component {
     this.setState({ type });
   }
 
+  toggleFrench = () => {
+    if (this.state.locale === 'en') {
+      this.setState({ locale: 'fr', localeObj: frLocale });
+    } else {
+      this.setState({ locale: 'en', localeObj: enLocale });
+    }
+  }
+
   render() {
     return (
       <JssProvider jss={jss}>
         <MuiThemeProvider theme={this.getMuiTheme()}>
-          <MuiPickersUtilsProvider utils={dateFnsUtils}>
+          <MuiPickersUtilsProvider utils={dateFnsUtils} locale={this.state.localeObj}>
             <Layout
               toggleDirection={this.toggleDirection}
               toggleThemeType={this.toggleThemeType}
-              toggleFrench={this.props.toggleFrench}
+              toggleFrench={this.toggleFrench}
             >
               <Routes />
             </Layout>

--- a/docs/src/Examples/Localization/DateFnsLocalizationExample.jsx
+++ b/docs/src/Examples/Localization/DateFnsLocalizationExample.jsx
@@ -1,12 +1,12 @@
 import React, { PureComponent } from 'react';
-import frLocale from 'date-fns/locale/fr';
-import ruLocale from 'date-fns/locale/ru';
-import enLocale from 'date-fns/locale/en-US';
-
 import DatePicker from 'material-ui-pickers/DatePicker';
 import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
 import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
 import { Icon, IconButton, Menu, MenuItem } from 'material-ui';
+
+import frLocale from 'date-fns/locale/fr';
+import ruLocale from 'date-fns/locale/ru';
+import enLocale from 'date-fns/locale/en-US';
 
 const localeMap = {
   en: enLocale,
@@ -54,8 +54,8 @@ export default class DateFnsLocalizationExample extends PureComponent {
             InputProps={{
               endAdornment: (
                 <IconButton
-                  aria-label="More"
-                  aria-owns={this.state.anchorEl ? 'long-menu' : null}
+                  aria-label="Select locale"
+                  aria-owns={this.state.anchorEl ? 'locale-menu' : null}
                   onClick={this.handleMenuOpen}
                 >
                   <Icon> more_vert </Icon>
@@ -66,10 +66,10 @@ export default class DateFnsLocalizationExample extends PureComponent {
         </div>
 
         <Menu
-          id="long-menu"
+          id="locale-menu"
           anchorEl={this.state.anchorEl}
           open={Boolean(this.state.anchorEl)}
-          onClose={this.handleClose}
+          onClose={this.handleMenuClose}
         >
           {
             Object.keys(localeMap).map(localeItem => (

--- a/docs/src/Examples/Localization/DateFnsLocalizationExample.jsx
+++ b/docs/src/Examples/Localization/DateFnsLocalizationExample.jsx
@@ -1,0 +1,89 @@
+import React, { PureComponent } from 'react';
+import frLocale from 'date-fns/locale/fr';
+import ruLocale from 'date-fns/locale/ru';
+import enLocale from 'date-fns/locale/en-US';
+
+import DatePicker from 'material-ui-pickers/DatePicker';
+import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
+import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
+import { Icon, IconButton, Menu, MenuItem } from 'material-ui';
+
+const localeMap = {
+  en: enLocale,
+  fr: frLocale,
+  ru: ruLocale,
+};
+
+export default class DateFnsLocalizationExample extends PureComponent {
+  state = {
+    selectedDate: new Date(),
+    anchorEl: null,
+    currentLocale: 'fr',
+  }
+
+  handleDateChange = (date) => {
+    this.setState({ selectedDate: date });
+  }
+
+  handleMenuOpen = (event) => {
+    event.stopPropagation();
+    this.setState({ anchorEl: event.currentTarget });
+  }
+
+  handleMenuClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  selectLocale = (selectedLocale) => {
+    this.setState({
+      currentLocale: selectedLocale,
+      anchorEl: null,
+    });
+  }
+
+  render() {
+    const { selectedDate } = this.state;
+    const locale = localeMap[this.state.currentLocale];
+
+    return (
+      <MuiPickersUtilsProvider utils={DateFnsUtils} locale={locale}>
+        <div className="picker">
+          <DatePicker
+            value={selectedDate}
+            onChange={this.handleDateChange}
+            InputProps={{
+              endAdornment: (
+                <IconButton
+                  aria-label="More"
+                  aria-owns={this.state.anchorEl ? 'long-menu' : null}
+                  onClick={this.handleMenuOpen}
+                >
+                  <Icon> more_vert </Icon>
+                </IconButton>
+              ),
+            }}
+          />
+        </div>
+
+        <Menu
+          id="long-menu"
+          anchorEl={this.state.anchorEl}
+          open={Boolean(this.state.anchorEl)}
+          onClose={this.handleClose}
+        >
+          {
+            Object.keys(localeMap).map(localeItem => (
+              <MenuItem
+                key={localeItem}
+                selected={localeItem === this.state.locale}
+                onClick={() => this.selectLocale(localeItem)}
+              >
+                {localeItem}
+              </MenuItem>
+            ))
+          }
+        </Menu>
+      </MuiPickersUtilsProvider>
+    );
+  }
+}

--- a/docs/src/Routes/GettingStarted/Installation.jsx
+++ b/docs/src/Routes/GettingStarted/Installation.jsx
@@ -13,7 +13,7 @@ npm i -s moment`;
 const Installation = () => (
   <div>
     <Typography variant="display2" gutterBottom> Installation </Typography>
-    <Typography variant="body1" gutterBottom> Available as <a href="https://www.npmjs.com/package/material-ui-pickers"> npm package </a> </Typography>
+    <Typography variant="body1" gutterBottom> Available as <a className="link" href="https://www.npmjs.com/package/material-ui-pickers"> npm package </a> </Typography>
 
     <Code withMargin text="npm i -s material-ui-pickers" />
 

--- a/docs/src/Routes/Localization/DateFnsLocalization.jsx
+++ b/docs/src/Routes/Localization/DateFnsLocalization.jsx
@@ -15,7 +15,7 @@ const DateFnsLocalization = () => (
       sourceFile="Localization/DateFnsLocalizationExample.jsx"
       description={(
         <Typography variant="body1" gutterBottom>
-         Note that pickers would be rerender automatically on locale change
+          Note that pickers would be rerender automatically on locale change
         </Typography>
       )}
     />

--- a/docs/src/Routes/Localization/DateFnsLocalization.jsx
+++ b/docs/src/Routes/Localization/DateFnsLocalization.jsx
@@ -4,18 +4,20 @@ import { Typography } from 'material-ui';
 
 const DateFnsLocalization = () => (
   <div>
-    <Typography variant="display1" gutterBottom> Localization date-fns </Typography>
+    <Typography variant="display2" gutterBottom> Localization date-fns </Typography>
     <Typography variant="body1" gutterBottom>
       Date-fns localization simply performs by passing date-fns locale object
       to the MuiPickerUtilsProvider
-    </Typography>
-    <Typography variant="body1" gutterBottom>
-      Note that pickers would be rerender automatically on locale change
     </Typography>
 
     <SourcablePanel
       title="Localized example"
       sourceFile="Localization/DateFnsLocalizationExample.jsx"
+      description={(
+        <Typography variant="body1" gutterBottom>
+         Note that pickers would be rerender automatically on locale change
+        </Typography>
+      )}
     />
   </div>
 );

--- a/docs/src/Routes/Localization/DateFnsLocalization.jsx
+++ b/docs/src/Routes/Localization/DateFnsLocalization.jsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import SourcablePanel from '_shared/SourcablePanel';
+import { Typography } from 'material-ui';
+
+const DateFnsLocalization = () => (
+  <div>
+    <Typography variant="display1" gutterBottom> Localization date-fns </Typography>
+    <Typography variant="body1" gutterBottom>
+      Date-fns localization simply performs by passing date-fns locale object
+      to the MuiPickerUtilsProvider
+    </Typography>
+    <Typography variant="body1" gutterBottom>
+      Note that pickers would be rerender automatically on locale change
+    </Typography>
+
+    <SourcablePanel
+      title="Localized example"
+      sourceFile="Localization/DateFnsLocalizationExample.jsx"
+    />
+  </div>
+);
+
+export default DateFnsLocalization;
+

--- a/docs/src/Routes/Routes.jsx
+++ b/docs/src/Routes/Routes.jsx
@@ -5,6 +5,7 @@ import Demos from './Demos';
 import Landing from './Landing/Landing';
 import Installation from './GettingStarted/Installation';
 import Usage from './GettingStarted/Usage';
+import DateFnsLocalization from './Localization/DateFnsLocalization';
 
 export default () => (
   <Switch>
@@ -12,6 +13,8 @@ export default () => (
     <Route path="/installation" component={Installation} />
     <Route path="/usage" component={Usage} />
     <Route path="/demo" component={Demos} />
+    <Route path="/localization/date-fns" component={DateFnsLocalization} />
+    <Route path="/localization/moment" component={DateFnsLocalization} />
   </Switch>
 );
 

--- a/docs/src/layout/NavigationMenu.jsx
+++ b/docs/src/layout/NavigationMenu.jsx
@@ -13,6 +13,15 @@ const NavigationMenu = ({ classes }) => (
       <ListItem button> Usage </ListItem>
     </Link>
 
+    <ListSubheader component="div"> Localization </ListSubheader>
+    <Link to="/localization/date-fns" className={classes.navLink}>
+      <ListItem button> Using date-fns </ListItem>
+    </Link>
+
+    <Link to="/localization/moment" className={classes.navLink}>
+      <ListItem button> Using moment </ListItem>
+    </Link>
+
     <ListSubheader component="div"> Components </ListSubheader>
     <Link to="/demo/datepicker" className={classes.navLink}>
       <ListItem button> Date Picker </ListItem>

--- a/lib/__tests__/test-utils.js
+++ b/lib/__tests__/test-utils.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import * as enzyme from 'enzyme';
-import dateFnsUtils from '../src/utils/date-fns-utils';
-import momentUtils from '../src/utils/moment-utils';
+import DateFnsUtils from '../src/utils/date-fns-utils';
+import MomentUtils from '../src/utils/moment-utils';
 
 export const utilsToUse = process.env.UTILS === 'moment'
-  ? momentUtils
-  : dateFnsUtils;
+  ? new MomentUtils()
+  : new DateFnsUtils();
 
 const getComponentWithUtils = Component => React.cloneElement(Component, { utils: utilsToUse });
 

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -76,7 +76,9 @@ export class Calendar extends Component {
     const { utils, disablePast, minDate } = this.props;
     const now = utils.date();
     return !utils.isBefore(
-      utils.getStartOfMonth(disablePast && utils.isAfter(now, minDate) ? now : minDate),
+      utils.getStartOfMonth(disablePast && utils.isAfter(now, minDate)
+        ? now
+        : utils.date(minDate)),
       this.state.currentMonth,
     );
   };
@@ -85,7 +87,9 @@ export class Calendar extends Component {
     const { utils, disableFuture, maxDate } = this.props;
     const now = utils.date();
     return !utils.isAfter(
-      utils.getStartOfMonth(disableFuture && utils.isBefore(now, maxDate) ? now : maxDate),
+      utils.getStartOfMonth(disableFuture && utils.isBefore(now, maxDate)
+        ? now
+        : utils.date(maxDate)),
       this.state.currentMonth,
     );
   };

--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -26,7 +26,7 @@ export class Calendar extends Component {
     /** @ignore */
     theme: PropTypes.object.isRequired,
     shouldDisableDate: PropTypes.func,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
   };
 
   static defaultProps = {

--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -65,7 +65,7 @@ CalendarHeader.propTypes = {
   rightArrowIcon: PropTypes.node,
   disablePrevMonth: PropTypes.bool,
   disableNextMonth: PropTypes.bool,
-  utils: PropTypes.func.isRequired,
+  utils: PropTypes.object.isRequired,
 };
 
 CalendarHeader.defaultProps = {

--- a/lib/src/DatePicker/DatePicker.jsx
+++ b/lib/src/DatePicker/DatePicker.jsx
@@ -22,7 +22,7 @@ export class DatePicker extends PureComponent {
     leftArrowIcon: PropTypes.node,
     rightArrowIcon: PropTypes.node,
     renderDay: PropTypes.func,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     shouldDisableDate: PropTypes.func,
   }
 

--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -16,7 +16,7 @@ export class YearSelection extends PureComponent {
     disablePast: PropTypes.bool.isRequired,
     disableFuture: PropTypes.bool.isRequired,
     animateYearScrolling: PropTypes.bool,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
   }
 
   static defaultProps = {

--- a/lib/src/DatePicker/index.jsx
+++ b/lib/src/DatePicker/index.jsx
@@ -40,7 +40,7 @@ export class DatePickerWrapper extends PickerBase {
     /* Custom renderer for day renderDay(date, selectedDate, dayInCurrentMonth) */
     renderDay: PropTypes.func,
     /* Date displaying utils */
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     /* Disable specific date hook */
     shouldDisableDate: PropTypes.func,
   }

--- a/lib/src/DateTimePicker/DateTimePicker.jsx
+++ b/lib/src/DateTimePicker/DateTimePicker.jsx
@@ -30,7 +30,7 @@ export class DateTimePicker extends Component {
     dateRangeIcon: PropTypes.node,
     timeIcon: PropTypes.node,
     renderDay: PropTypes.func,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     ampm: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
     animateYearScrolling: PropTypes.bool,

--- a/lib/src/DateTimePicker/DateTimePickerHeader.jsx
+++ b/lib/src/DateTimePicker/DateTimePickerHeader.jsx
@@ -93,7 +93,7 @@ DateTimePickerHeader.propTypes = {
   openView: PropTypes.string.isRequired,
   onOpenViewChange: PropTypes.func.isRequired,
   setMeridiemMode: PropTypes.func.isRequired,
-  utils: PropTypes.func.isRequired,
+  utils: PropTypes.object.isRequired,
   ampm: PropTypes.bool,
 };
 

--- a/lib/src/DateTimePicker/index.jsx
+++ b/lib/src/DateTimePicker/index.jsx
@@ -29,7 +29,7 @@ export class DateTimePickerWrapper extends PickerBase {
     timeIcon: PropTypes.node,
     renderDay: PropTypes.func,
     labelFunc: PropTypes.func,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     ampm: PropTypes.bool,
     shouldDisableDate: PropTypes.func,
     animateYearScrolling: PropTypes.bool,

--- a/lib/src/TimePicker/HourView.jsx
+++ b/lib/src/TimePicker/HourView.jsx
@@ -9,7 +9,7 @@ export class HourView extends PureComponent {
   static propTypes = {
     date: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     ampm: PropTypes.bool,
   }
 

--- a/lib/src/TimePicker/MinutesView.jsx
+++ b/lib/src/TimePicker/MinutesView.jsx
@@ -9,7 +9,7 @@ export class MinutesView extends Component {
   static propTypes = {
     date: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
   }
 
   static defaultProps = {

--- a/lib/src/TimePicker/TimePicker.jsx
+++ b/lib/src/TimePicker/TimePicker.jsx
@@ -15,7 +15,7 @@ export class TimePicker extends Component {
     classes: PropTypes.object.isRequired,
     theme: PropTypes.object.isRequired,
     children: PropTypes.node,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     ampm: PropTypes.bool,
   }
 

--- a/lib/src/TimePicker/index.jsx
+++ b/lib/src/TimePicker/index.jsx
@@ -18,7 +18,7 @@ export class TimePickerWrapper extends PickerBase {
     onChange: PropTypes.func.isRequired,
     autoOk: PropTypes.bool,
     invalidLabel: PropTypes.string,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     ampm: PropTypes.bool,
   }
 

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -41,7 +41,7 @@ export class DateTextField extends PureComponent {
     invalidDateMessage: PropTypes.string,
     clearable: PropTypes.bool,
     TextFieldComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
     InputAdornmentProps: PropTypes.object,
     adornmentPosition: PropTypes.oneOf(['start', 'end']),
   }
@@ -143,7 +143,8 @@ export class DateTextField extends PureComponent {
       nextProps.format !== this.props.format ||
       nextProps.maxDate !== this.props.maxDate ||
       nextProps.minDate !== this.props.minDate ||
-      nextProps.emptyLabel !== this.props.emptyLabel
+      nextProps.emptyLabel !== this.props.emptyLabel ||
+      nextProps.utils !== this.props.utils
     ) {
       this.setState(this.updateState(nextProps));
     }

--- a/lib/src/_shared/PickerBase.jsx
+++ b/lib/src/_shared/PickerBase.jsx
@@ -12,7 +12,7 @@ export default class PickerBase extends PureComponent {
     format: PropTypes.string,
     labelFunc: PropTypes.func,
     ampm: PropTypes.bool,
-    utils: PropTypes.func.isRequired,
+    utils: PropTypes.object.isRequired,
   }
 
   getValidDateOrCurrent = (props = this.props) => {

--- a/lib/src/_shared/WithUtils.jsx
+++ b/lib/src/_shared/WithUtils.jsx
@@ -12,7 +12,7 @@ const withUtils = () => (Component) => {
   };
 
   WithUtils.contextTypes = {
-    muiPickersDateUtils: PropTypes.func,
+    muiPickersDateUtils: PropTypes.object,
   };
 
   WithUtils.displayName = `withUtils${Component.displayName || Component.name}`;

--- a/lib/src/utils/MuiPickersUtilsProvider.jsx
+++ b/lib/src/utils/MuiPickersUtilsProvider.jsx
@@ -4,16 +4,22 @@ import PropTypes from 'prop-types';
 export default class MuiPickersUtilsProvider extends PureComponent {
   static propTypes = {
     utils: PropTypes.func.isRequired,
+    locale: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     children: PropTypes.element.isRequired,
   }
 
+  static defaultProps = {
+    locale: undefined,
+  }
+
   static childContextTypes = {
-    muiPickersDateUtils: PropTypes.func,
+    muiPickersDateUtils: PropTypes.object,
   }
 
   getChildContext() {
+    const { utils: Utils, locale } = this.props;
     return {
-      muiPickersDateUtils: this.props.utils,
+      muiPickersDateUtils: new Utils(locale),
     };
   }
 

--- a/lib/src/utils/MuiPickersUtilsProvider.jsx
+++ b/lib/src/utils/MuiPickersUtilsProvider.jsx
@@ -6,10 +6,12 @@ export default class MuiPickersUtilsProvider extends PureComponent {
     utils: PropTypes.func.isRequired,
     locale: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
     children: PropTypes.element.isRequired,
+    moment: PropTypes.func,
   }
 
   static defaultProps = {
     locale: undefined,
+    moment: undefined,
   }
 
   static childContextTypes = {
@@ -17,9 +19,9 @@ export default class MuiPickersUtilsProvider extends PureComponent {
   }
 
   getChildContext() {
-    const { utils: Utils, locale } = this.props;
+    const { utils: Utils, locale, moment } = this.props;
     return {
-      muiPickersDateUtils: new Utils(locale),
+      muiPickersDateUtils: new Utils({ locale, moment }),
     };
   }
 

--- a/lib/src/utils/date-fns-utils.js
+++ b/lib/src/utils/date-fns-utils.js
@@ -24,7 +24,7 @@ import getYear from 'date-fns/getYear';
 import isEqual from 'date-fns/isEqual';
 
 export default class DateFnsUtils {
-  constructor(locale) {
+  constructor({ locale }) {
     this.locale = locale;
   }
 

--- a/lib/src/utils/date-fns-utils.js
+++ b/lib/src/utils/date-fns-utils.js
@@ -24,7 +24,11 @@ import getYear from 'date-fns/getYear';
 import isEqual from 'date-fns/isEqual';
 
 export default class DateFnsUtils {
-  static date(value) {
+  constructor(locale) {
+    this.locale = locale;
+  }
+
+  date(value) {
     if (typeof value === 'undefined') {
       return new Date();
     }
@@ -32,87 +36,89 @@ export default class DateFnsUtils {
     return new Date(value);
   }
 
-  static parse = (value, formatString) => parse(value, formatString, new Date())
+  parse = (value, formatString) => parse(value, formatString, new Date())
 
-  static addDays = addDays
+  format(date, formatString) {
+    return format(date, formatString, { locale: this.locale });
+  }
 
-  static isValid = isValid
+  addDays = addDays
 
-  static isEqual = isEqual
+  isValid = isValid
 
-  static isNull(date) {
+  isEqual = isEqual
+
+  isNull(date) {
     return date == null;
   }
 
-  static isAfter = isAfter
+  isAfter = isAfter
 
-  static isBefore = isBefore
+  isBefore = isBefore
 
-  static isAfterDay(date, value) {
+  isAfterDay(date, value) {
     return isAfter(date, endOfDay(value));
   }
 
-  static isBeforeDay(date, value) {
+  isBeforeDay(date, value) {
     return isBefore(date, startOfDay(value));
   }
 
-  static isBeforeYear(date, value) {
+  isBeforeYear(date, value) {
     return isBefore(date, startOfYear(value));
   }
 
-  static isAfterYear(date, value) {
+  isAfterYear(date, value) {
     return isAfter(date, endOfYear(value));
   }
 
-  static startOfDay = startOfDay
+  startOfDay = startOfDay
 
-  static endOfDay = endOfDay
+  endOfDay = endOfDay
 
-  static format = format
-
-  static formatNumber(num) {
+  formatNumber(num) {
     return num;
   }
 
-  static getHours = getHours
+  getHours = getHours
 
-  static setHours = setHours
+  setHours = setHours
 
-  static getMinutes(date) {
+  getMinutes(date) {
     return date.getMinutes();
   }
 
-  static setMinutes = setMinutes
+  setMinutes = setMinutes
 
-  static getMonth(date) {
+  getMonth(date) {
     return date.getMonth();
   }
 
-  static isSameDay = isSameDay;
+  isSameDay = isSameDay;
 
-  static getMeridiemText(ampm) {
+  getMeridiemText(ampm) {
     return ampm === 'am' ? 'AM' : 'PM';
   }
 
-  static getStartOfMonth = startOfMonth
+  getStartOfMonth = startOfMonth
 
-  static getNextMonth(date) {
+  getNextMonth(date) {
     return addMonths(date, 1);
   }
 
-  static getPreviousMonth(date) {
+  getPreviousMonth(date) {
     return addMonths(date, -1);
   }
 
-  static getYear = getYear
+  getYear = getYear
 
-  static setYear = setYear;
+  setYear = setYear;
 
-  static getWeekdays() {
+  getWeekdays() {
     return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => format(setDay(new Date(), dayOfWeek), 'dd'));
   }
 
-  static getWeekArray(date) {
+  getWeekArray(date) {
     const start = startOfWeek(startOfMonth(date));
     const end = endOfWeek(endOfMonth(date));
 
@@ -130,7 +136,7 @@ export default class DateFnsUtils {
     return nestedWeeks;
   }
 
-  static getYearRange(start, end) {
+  getYearRange(start, end) {
     const startDate = new Date(start);
     const endDate = new Date(end);
     const years = [];
@@ -143,31 +149,31 @@ export default class DateFnsUtils {
   }
 
   // displaying methpds
-  static getCalendarHeaderText(date) {
-    return format(date, 'MMMM YYYY');
+  getCalendarHeaderText(date) {
+    return format(date, 'MMMM YYYY', { locale: this.locale });
   }
 
-  static getYearText(date) {
-    return format(date, 'YYYY');
+  getYearText(date) {
+    return format(date, 'YYYY', { locale: this.locale });
   }
 
-  static getDatePickerHeaderText(date) {
-    return format(date, 'ddd, MMM D');
+  getDatePickerHeaderText(date) {
+    return format(date, 'ddd, MMM D', { locale: this.locale });
   }
 
-  static getDateTimePickerHeaderText(date) {
-    return format(date, 'MMM D');
+  getDateTimePickerHeaderText(date) {
+    return format(date, 'MMM D', { locale: this.locale });
   }
 
-  static getDayText(date) {
-    return format(date, 'D');
+  getDayText(date) {
+    return format(date, 'D', { locale: this.locale });
   }
 
-  static getHourText(date, ampm) {
-    return format(date, ampm ? 'hh' : 'HH');
+  getHourText(date, ampm) {
+    return format(date, ampm ? 'hh' : 'HH', { locale: this.locale });
   }
 
-  static getMinuteText(date) {
-    return format(date, 'mm');
+  getMinuteText(date) {
+    return format(date, 'mm', { locale: this.locale });
   }
 }

--- a/lib/src/utils/date-fns-utils.js
+++ b/lib/src/utils/date-fns-utils.js
@@ -24,7 +24,7 @@ import getYear from 'date-fns/getYear';
 import isEqual from 'date-fns/isEqual';
 
 export default class DateFnsUtils {
-  constructor({ locale }) {
+  constructor({ locale } = {}) {
     this.locale = locale;
   }
 

--- a/lib/src/utils/date-fns-utils.js
+++ b/lib/src/utils/date-fns-utils.js
@@ -115,7 +115,7 @@ export default class DateFnsUtils {
   setYear = setYear;
 
   getWeekdays() {
-    return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => format(setDay(new Date(), dayOfWeek), 'dd'));
+    return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => format(setDay(new Date(), dayOfWeek), 'dd', { locale: this.locale }));
   }
 
   getWeekArray(date) {

--- a/lib/src/utils/moment-utils.js
+++ b/lib/src/utils/moment-utils.js
@@ -1,7 +1,7 @@
 import defaultMoment from 'moment';
 
 export default class MomentUtils {
-  constructor({ locale, moment }) {
+  constructor({ locale, moment } = {}) {
     /* eslint-disable-next-line */
     this.moment = moment || defaultMoment
     this.locale = locale;

--- a/lib/src/utils/moment-utils.js
+++ b/lib/src/utils/moment-utils.js
@@ -1,123 +1,127 @@
 import moment from 'moment';
 
 export default class MomentUtils {
-  static parse = moment
+  constructor(locale) {
+    this.locale = locale;
+  }
 
-  static date(value, formatString) {
+  parse = moment
+
+  date(value, formatString) {
     return moment(value, formatString);
   }
 
-  static isValid(date) {
+  isValid(date) {
     return date.isValid();
   }
 
-  static isNull(date) {
+  isNull(date) {
     return date.parsingFlags().nullInput;
   }
 
-  static isAfter(date, value) {
+  isAfter(date, value) {
     return date.isAfter(value);
   }
 
-  static isBefore(date, value) {
+  isBefore(date, value) {
     return date.isBefore(value);
   }
 
-  static isAfterDay(date, value) {
+  isAfterDay(date, value) {
     return date.isAfter(value, 'day');
   }
 
-  static isBeforeDay(date, value) {
+  isBeforeDay(date, value) {
     return date.isBefore(value, 'day');
   }
 
-  static isBeforeYear(date, value) {
+  isBeforeYear(date, value) {
     return date.isBefore(value, 'year');
   }
 
-  static isAfterYear(date, value) {
+  isAfterYear(date, value) {
     return date.isAfter(value, 'year');
   }
 
-  static startOfDay(date) {
+  startOfDay(date) {
     return date.clone().startOf('day');
   }
 
-  static endOfDay(date) {
+  endOfDay(date) {
     return date.clone().endOf('day');
   }
 
-  static format(date, formatString) {
+  format(date, formatString) {
     return date.format(formatString);
   }
 
-  static formatNumber(num) {
+  formatNumber(num) {
     return num;
   }
 
-  static getHours(date) {
+  getHours(date) {
     return date.get('hours');
   }
 
-  static addDays(date, count) {
+  addDays(date, count) {
     return count < 0
       ? date.clone().subtract(Math.abs(count), 'days')
       : date.clone().add(count, 'days');
   }
 
-  static setHours(date, value) {
+  setHours(date, value) {
     return date.clone().hours(value);
   }
 
-  static getMinutes(date) {
+  getMinutes(date) {
     return date.get('minutes');
   }
 
-  static setMinutes(date, value) {
+  setMinutes(date, value) {
     return date.clone().minutes(value);
   }
 
-  static getMonth(date) {
+  getMonth(date) {
     return date.get('month');
   }
 
-  static isSameDay(date, comparing) {
+  isSameDay(date, comparing) {
     return date.isSame(comparing, 'day');
   }
 
-  static getMeridiemText(ampm) {
+  getMeridiemText(ampm) {
     return ampm === 'am' ? 'AM' : 'PM';
   }
 
-  static getStartOfMonth(date) {
+  getStartOfMonth(date) {
     return date.clone().startOf('month');
   }
 
-  static getNextMonth(date) {
+  getNextMonth(date) {
     return date.clone().add(1, 'month');
   }
 
-  static getPreviousMonth(date) {
+  getPreviousMonth(date) {
     return date.clone().subtract(1, 'month');
   }
 
-  static getYear(date) {
+  getYear(date) {
     return date.get('year');
   }
 
-  static setYear(date, year) {
+  setYear(date, year) {
     return date.clone().set('year', year);
   }
 
-  static getWeekdays() {
+  getWeekdays() {
     return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => moment().weekday(dayOfWeek).format('dd')[0]);
   }
 
-  static isEqual(value, comparing) {
+  isEqual(value, comparing) {
     return moment(value).isSame(comparing);
   }
 
-  static getWeekArray(date) {
+  getWeekArray(date) {
     const start = date.clone().startOf('month').startOf('week');
     const end = date.clone().endOf('month').endOf('week');
 
@@ -135,7 +139,7 @@ export default class MomentUtils {
     return nestedWeeks;
   }
 
-  static getYearRange(start, end) {
+  getYearRange(start, end) {
     const startDate = moment(start);
     const endDate = moment(end);
     const years = [];
@@ -150,31 +154,31 @@ export default class MomentUtils {
   }
 
   // displaying methods
-  static getCalendarHeaderText(date) {
+  getCalendarHeaderText(date) {
     return date.format('MMMM YYYY');
   }
 
-  static getYearText(date) {
+  getYearText(date) {
     return date.format('YYYY');
   }
 
-  static getDatePickerHeaderText(date) {
+  getDatePickerHeaderText(date) {
     return date.format('ddd, MMM D');
   }
 
-  static getDateTimePickerHeaderText(date) {
+  getDateTimePickerHeaderText(date) {
     return date.format('MMM D');
   }
 
-  static getDayText(date) {
+  getDayText(date) {
     return date.format('D');
   }
 
-  static getHourText(date, ampm) {
+  getHourText(date, ampm) {
     return date.format(ampm ? 'hh' : 'HH');
   }
 
-  static getMinuteText(date) {
+  getMinuteText(date) {
     return date.format('mm');
   }
 }

--- a/lib/src/utils/moment-utils.js
+++ b/lib/src/utils/moment-utils.js
@@ -1,14 +1,16 @@
-import moment from 'moment';
+import defaultMoment from 'moment';
 
 export default class MomentUtils {
-  constructor(locale) {
+  constructor({ locale, moment }) {
+    /* eslint-disable-next-line */
+    this.moment = moment || defaultMoment
     this.locale = locale;
   }
 
-  parse = moment
+  parse = this.moment
 
   date(value, formatString) {
-    return moment(value, formatString);
+    return this.moment(value, formatString);
   }
 
   isValid(date) {
@@ -94,11 +96,11 @@ export default class MomentUtils {
   }
 
   getStartOfMonth(date) {
-    return date.clone().startOf('month');
+    return this.moment(date).clone().startOf('month');
   }
 
   getNextMonth(date) {
-    return date.clone().add(1, 'month');
+    return this.moment(date).clone().add(1, 'month');
   }
 
   getPreviousMonth(date) {
@@ -114,11 +116,11 @@ export default class MomentUtils {
   }
 
   getWeekdays() {
-    return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => moment().weekday(dayOfWeek).format('dd')[0]);
+    return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => this.moment().weekday(dayOfWeek).format('dd')[0]);
   }
 
   isEqual(value, comparing) {
-    return moment(value).isSame(comparing);
+    return this.moment(value).isSame(comparing);
   }
 
   getWeekArray(date) {
@@ -140,8 +142,8 @@ export default class MomentUtils {
   }
 
   getYearRange(start, end) {
-    const startDate = moment(start);
-    const endDate = moment(end);
+    const startDate = this.moment(start);
+    const endDate = this.moment(end);
     const years = [];
 
     let current = startDate;

--- a/lib/src/utils/moment-utils.js
+++ b/lib/src/utils/moment-utils.js
@@ -96,11 +96,11 @@ export default class MomentUtils {
   }
 
   getStartOfMonth(date) {
-    return this.moment(date).clone().startOf('month');
+    return date.clone().startOf('month');
   }
 
   getNextMonth(date) {
-    return this.moment(date).clone().add(1, 'month');
+    return date.clone().add(1, 'month');
   }
 
   getPreviousMonth(date) {


### PR DESCRIPTION
Changed utils to be the instantiate object, add prop `locale` to the `MuiPickersUtilsProvider`, which will contain localization object for date-fns and just string for moment.

Also add an ability to pass moment object with selected locale and timezone defaults, which actually closes #251 
