### PR TITLE
Add missing import in Moment locale example

### DIFF
--- a/docs/src/Examples/Localization/MomentLocalizationExample.jsx
+++ b/docs/src/Examples/Localization/MomentLocalizationExample.jsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import moment from 'moment';
+import 'moment/locale/fr'; // this is the important bit, you have to import the locale your'e trying to use.
 import MomentUtils from 'material-ui-pickers/utils/moment-utils';
 import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
 


### PR DESCRIPTION
according to https://momentjs.com/docs/#/i18n/loading-into-browser/ locales have to be imported before being used.

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

- [x] I have changed my target branch to **develop** :facepunch:

## Description
Hi,
first off, this module looks great! 
However, after spending too much time trying to figure out how to use moment, we found that the example was missing an import statement.

Hope this will get merged and help people skip the hours we've spent :)
Thank!