### PR TITLE
Do not pass disableOpenOnEnter prop to TextField component

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-pickers",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0-rc.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/lib/src/_shared/DateTextField.jsx
+++ b/lib/src/_shared/DateTextField.jsx
@@ -267,6 +267,7 @@ export class DateTextField extends PureComponent {
       TextFieldComponent,
       InputAdornmentProps,
       adornmentPosition,
+      disableOpenOnEnter,
       ...other
     } = this.props;
 


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 

### Issue # <!-- Please refer issue number here, if exists -->

## Description
Currently `disableOpenOnEnter` is passed to `TextField` component using `{...other}`, which causes React error in console.
This PR fixes this behaviour.