### PR TITLE
Added clear initial state example, and fixed selectedDate for IE users.

### DIFF
--- a/docs/src/Examples/Demo/CustomDateTimePicker.jsx
+++ b/docs/src/Examples/Demo/CustomDateTimePicker.jsx
@@ -4,11 +4,16 @@ import { IconButton, Icon, InputAdornment } from 'material-ui';
 
 export default class CustomDateTimePicker extends PureComponent {
   state = {
-    selectedDate: new Date('2018-01-01 18:54'),
+    selectedDate: new Date('2018-01-01T18:54'),
+    clearedDate: null
+
   }
 
   handleDateChange = (date) => {
     this.setState({ selectedDate: date });
+  }
+  handleClearedDateChange = (date) => {
+    this.setState({ clearedDate: date });
   }
 
   render() {
@@ -52,6 +57,15 @@ export default class CustomDateTimePicker extends PureComponent {
             format="YYYY/MM/DD hh:mm A"
             disableOpenOnEnter
             mask={[/\d/, /\d/, /\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, ' ', /\d/, /\d/, ':', /\d/, /\d/, ' ', /a|p/i, 'M']}
+          />
+        </div>
+
+        <div className="picker">
+          <DateTimePicker
+            value={clearedDate}
+            onChange={this.handleClearedDateChange}
+            helperText="Clear Initial State"
+            clearable
           />
         </div>
       </Fragment>


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

- [ x] I have changed my target branch to **develop** :facepunch: 

### Issue # <!-- Please refer issue number here, if exists -->
#352

## Description
I have added an example of a clear initial state.  This allows the picker to be null as default, for example as an optional search parameter in a search form.

I have also fixed the date assigned to selectedDate on the customDateTimePicker page. While the example you had works great in new browsers, it shows up as unknown in IE.  Adding the "T" back in repairs this issue. 
