### PR TITLE
Enter key validates selected date and time

### DIFF
--- a/lib/src/_shared/ModalDialog.jsx
+++ b/lib/src/_shared/ModalDialog.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import EventListener from 'react-event-listener';
 import withStyles from 'material-ui/styles/withStyles';
 import Button from 'material-ui/Button';
 import Dialog from 'material-ui/Dialog/Dialog';
@@ -42,6 +43,7 @@ const styles = {
 export const ModalDialog = ({
   children,
   classes,
+  onKeyDown,
   onAccept,
   onDismiss,
   onClear,
@@ -56,6 +58,8 @@ export const ModalDialog = ({
   ...other
 }) => (
   <Dialog onClose={onDismiss} classes={{ paper: classes.dialogRoot }} {...other}>
+    <EventListener target="window" onKeyDown={onKeyDown} />
+
     <DialogContent className={classnames(classes.dialog, dialogContentClassName)}>
       { children }
     </DialogContent>
@@ -111,6 +115,7 @@ export const ModalDialog = ({
 
 ModalDialog.propTypes = {
   children: PropTypes.node.isRequired,
+  onKeyDown: PropTypes.func.isRequired,
   onAccept: PropTypes.func.isRequired,
   onDismiss: PropTypes.func.isRequired,
   onClear: PropTypes.func.isRequired,

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -1,5 +1,6 @@
 import React, { Fragment, PureComponent } from 'react';
 import PropTypes from 'prop-types';
+import keycode from 'keycode';
 import ModalDialog from '../_shared/ModalDialog';
 import DateTextField from '../_shared/DateTextField';
 import DomainPropTypes from '../constants/prop-types';
@@ -63,6 +64,20 @@ export default class ModalWrapper extends PureComponent {
   state = {
     open: false,
   }
+
+  handleKeyDown = (event) => {
+    switch (keycode(event)) {
+      case 'enter':
+        this.handleAccept();
+        break;
+      default:
+        // if keycode is not handled, stop execution
+        return;
+    }
+
+    // if event was handled prevent other side effects
+    event.preventDefault();
+  };
 
   handleSetTodayDate = () => {
     if (this.props.onSetToday) {
@@ -142,6 +157,7 @@ export default class ModalWrapper extends PureComponent {
 
         <ModalDialog
           open={this.state.open}
+          onKeyDown={this.handleKeyDown}
           onClear={this.handleClear}
           onAccept={this.handleAccept}
           onDismiss={this.handleDismiss}


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [ x ] I have changed my target branch to **develop** :facepunch: 

## Description

As it is possible to change selected day with arrow keys (in `DatePicker` only), it was missing the enter key validation. Now it is possible to validate any type of picker with enter key.

It may be interesting to improve navigation with keyboard, to handle time and date with arrow keys, but it's a more complex work.