### PR TITLE
[#406] [typescript] Make utils prop of MuiPickersUtilsProvider typed …

### DIFF
--- a/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
+++ b/lib/__tests__/DatePicker/DatePickerWrapper.usage.tsx
@@ -53,10 +53,9 @@ class CustomElements extends Component<{classes: any}, {selectedDate: Date}> {
       return '';
     }
 
-    return date && date.isValid() ?
-      `Week of ${date.clone().startOf('week').format('MMM Do')}`
-      :
-      invalidLabel;
+    return date && date.isValid() 
+      ? `Week of ${date.clone().startOf('week').format('MMM Do')}`
+      : invalidLabel;
   }
 
   renderWrappedDefaultDay = (day: Moment, selectedDate: Moment, dayInCurrentMonth: boolean, dayComponent: DayComponent) => {

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -3233,8 +3233,7 @@
         "buffer-shims": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -3251,14 +3250,12 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "delayed-stream": "~1.0.0"
           }
@@ -3271,14 +3268,12 @@
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "cryptiles": {
           "version": "2.0.5",
@@ -3323,8 +3318,7 @@
         "delayed-stream": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
@@ -3356,8 +3350,7 @@
         "extsprintf": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "forever-agent": {
           "version": "0.6.1",
@@ -3540,8 +3533,7 @@
         "isarray": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
@@ -4031,7 +4023,7 @@
       "integrity": "sha512-E2s1b4GVbt8PyG+iaRN6ks8N0Oy2LOJz7SIMUwWWWx7Mr5Z08hKkfpkKQbOtOGqzkFpckDJHjjZ8qfigN2W86A==",
       "dev": true,
       "requires": {
-        "icu4c-data": "^0.61.2"
+        "icu4c-data": "^0.59.2"
       }
     },
     "function-bind": {

--- a/lib/src/utils/MuiPickersUtilsProvider.d.ts
+++ b/lib/src/utils/MuiPickersUtilsProvider.d.ts
@@ -1,12 +1,10 @@
 import { ComponentClass, ReactNode } from 'react';
 import { DateTimePickerView } from '../constants/date-picker-view';
-import DateFnsUtils from './date-fns-utils';
 import { MaterialUiPickersDate } from '../typings/date';
-import MomentUtils from './moment-utils';
-import LuxonUtils from './luxon-utils';
+import { Utils } from '../typings/utils';
 
 export interface MuiPickersUtilsProviderProps {
-  utils: typeof MomentUtils | typeof DateFnsUtils | typeof LuxonUtils;
+  utils: any;
   children: ReactNode;
   locale?: any;
   moment?: any;


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 

### Closes #406 <!-- Please refer issue number here, if exists -->

## Description
Do not restrict users on passing typed utils. (Actually this broking types because each utils imports lib-specific types)
In ts its not possible to do `typeof Utils<any>` https://github.com/Microsoft/TypeScript/issues/204
