### PR TITLE
Add todayLabel and showTodayButton to TS type definitions

### DIFF
--- a/lib/src/wrappers/ModalWrapper.d.ts
+++ b/lib/src/wrappers/ModalWrapper.d.ts
@@ -13,7 +13,7 @@ export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
     cancelLabel?: ReactNode;
     clearLabel?: ReactNode;
     todayLabel?: ReactNode;
-    showTodayButton: boolean;
+    showTodayButton?: boolean;
 }
 
 declare const ModalWrapper: ComponentClass<ModalWrapperProps>;

--- a/lib/src/wrappers/ModalWrapper.d.ts
+++ b/lib/src/wrappers/ModalWrapper.d.ts
@@ -12,6 +12,8 @@ export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
     okLabel?: ReactNode;
     cancelLabel?: ReactNode;
     clearLabel?: ReactNode;
+    todayLabel?: ReactNode;
+    showTodayButton: boolean;
 }
 
 declare const ModalWrapper: ComponentClass<ModalWrapperProps>;


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 

### Closes # <!-- Please refer issue number here, if exists -->
This fixes #460 
## Description
Type definition has been modified to include `todayLabel` and `showTodayButton` properties.