### PR TITLE
Fixed linting errors related to state and getDerivedStateFromProps

### DIFF
--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -42,10 +42,6 @@ export class Calendar extends Component {
     shouldDisableDate: () => false,
   };
 
-  state = {
-    currentMonth: this.props.utils.getStartOfMonth(this.props.date),
-  };
-
   static getDerivedStateFromProps(nextProps, state) {
     if (!nextProps.utils.isEqual(nextProps.date, state.lastDate)) {
       return {
@@ -56,6 +52,10 @@ export class Calendar extends Component {
 
     return null;
   }
+
+  state = {
+    currentMonth: this.props.utils.getStartOfMonth(this.props.date),
+  };
 
   componentDidMount() {
     const {

--- a/lib/src/utils/MuiPickersUtilsProvider.jsx
+++ b/lib/src/utils/MuiPickersUtilsProvider.jsx
@@ -21,14 +21,14 @@ export default class MuiPickersUtilsProvider extends PureComponent {
     moment: undefined,
   }
 
-  state = {
-    utils: null,
-  }
-
   static getDerivedStateFromProps({ utils: Utils, locale, moment }) {
     return {
       utils: new Utils({ locale, moment }),
     };
+  }
+
+  state = {
+    utils: null,
   }
 
   render() {

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -63,10 +63,6 @@ export default class ModalWrapper extends PureComponent {
     onSetToday: undefined,
   }
 
-  state = {
-    open: false,
-  }
-
   static getDerivedStateFromProps(nextProps) {
     // only if accept = true close the dialog
     if (nextProps.isAccepted) {
@@ -76,6 +72,10 @@ export default class ModalWrapper extends PureComponent {
     }
 
     return null;
+  }
+
+  state = {
+    open: false,
   }
 
   handleKeyDown = (event) => {


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 

### Closes None - minor linting issues

## Description

Fixes linting error related to state property assignment is required to appear after `getDerivedStateFromProps`