### PR TITLE
Make MuiPickerUtilsProvider component to make it works with Router HOC

### DIFF
--- a/lib/src/utils/MuiPickersUtilsProvider.jsx
+++ b/lib/src/utils/MuiPickersUtilsProvider.jsx
@@ -1,10 +1,10 @@
-import React, { PureComponent } from 'react';
+import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 
 const { Consumer, Provider } = React.createContext();
 export const MuiPickersContextConsumer = Consumer;
 
-export default class MuiPickersUtilsProvider extends PureComponent {
+export default class MuiPickersUtilsProvider extends Component {
   static propTypes = {
     /* eslint-disable react/no-unused-prop-types */
     utils: PropTypes.func.isRequired,


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 

### Closes #301 <!-- Please refer issue number here, if exists -->

## Description
The fix to replace PureComponent by Component for ReactRouter HOC to work seems to have been lost in the conversion to use React context. This PR puts it back.
