### PR TITLE
Add ability to change the container of the wrapped modal

### DIFF
--- a/lib/src/wrappers/ModalWrapper.d.ts
+++ b/lib/src/wrappers/ModalWrapper.d.ts
@@ -14,6 +14,7 @@ export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
     clearLabel?: ReactNode;
     todayLabel?: ReactNode;
     showTodayButton?: boolean;
+    container?: ReactNode;
 }
 
 declare const ModalWrapper: ComponentClass<ModalWrapperProps>;

--- a/lib/src/wrappers/ModalWrapper.jsx
+++ b/lib/src/wrappers/ModalWrapper.jsx
@@ -41,6 +41,7 @@ export default class ModalWrapper extends PureComponent {
     children: PropTypes.node.isRequired,
     dialogContentClassName: PropTypes.string,
     isAccepted: PropTypes.bool.isRequired,
+    container: PropTypes.node,
   }
 
   static defaultProps = {
@@ -61,6 +62,7 @@ export default class ModalWrapper extends PureComponent {
     onOpen: undefined,
     onClose: undefined,
     onSetToday: undefined,
+    container: undefined,
   }
 
   state = {
@@ -153,6 +155,7 @@ export default class ModalWrapper extends PureComponent {
       onClose,
       onSetToday,
       isAccepted,
+      container,
       ...other
     } = this.props;
 
@@ -183,6 +186,7 @@ export default class ModalWrapper extends PureComponent {
           cancelLabel={cancelLabel}
           clearable={clearable}
           showTodayButton={showTodayButton}
+          container={container}
         >
           {children}
         </ModalDialog>


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [X] I have changed my target branch to **develop** :facepunch: 

### Closes # <!-- Please refer issue number here, if exists -->

No existing issue for this PR

## Description

Goal of this change is to be able to specify a target container for the ModalWrapper.

Prop **container** is part of Modal API (see https://material-ui.com/api/modal/)