### PR TITLE
Remove unnecessary spacing in MuiPickersUtilsProvider

### DIFF
--- a/lib/src/utils/MuiPickersUtilsProvider.jsx
+++ b/lib/src/utils/MuiPickersUtilsProvider.jsx
@@ -32,6 +32,6 @@ export default class MuiPickersUtilsProvider extends Component {
   }
 
   render() {
-    return <Provider value={this.state.utils} children={this.props.children} />;
+    return <Provider value={this.state.utils}>{this.props.children}</Provider>;
   }
 }

--- a/lib/src/utils/MuiPickersUtilsProvider.jsx
+++ b/lib/src/utils/MuiPickersUtilsProvider.jsx
@@ -32,6 +32,6 @@ export default class MuiPickersUtilsProvider extends Component {
   }
 
   render() {
-    return <Provider value={this.state.utils}> {this.props.children} </Provider>;
+    return <Provider value={this.state.utils} children={this.props.children} />;
   }
 }


### PR DESCRIPTION
Right now the provider generates useless space characters in the DOM.