### PR TITLE
Build umd bundle

### DIFF
--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,20 +1,25 @@
 {
+  "build/dist/material-ui-pickers.umd.js": {
+    "bundled": 773228,
+    "minified": 315245,
+    "gzipped": 79507
+  },
   "build/dist/material-ui-pickers.cjs.js": {
-    "bundled": 118716,
-    "minified": 66127,
-    "gzipped": 13574
+    "bundled": 119387,
+    "minified": 66434,
+    "gzipped": 13624
   },
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 116379,
-    "minified": 63950,
-    "gzipped": 13449,
+    "bundled": 117050,
+    "minified": 64257,
+    "gzipped": 13494,
     "treeshaked": {
       "rollup": {
-        "code": 54271,
+        "code": 54563,
         "import_statements": 1159
       },
       "webpack": {
-        "code": 57814
+        "code": 58110
       }
     }
   }

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -198,7 +198,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@material-ui/core/-/core-1.3.0.tgz",
       "integrity": "sha512-igFIJ3zx1hnX0NHQrpiTiOZsIEo4U9134GfwhRn/pDfexmwU6RTGmQgJOklQElKqCLMKir3BGicGqDEztBMDOA==",
-      "dev": true,
       "requires": {
         "@babel/runtime": "7.0.0-beta.51",
         "@types/jss": "9.5.3",
@@ -267,7 +266,6 @@
       "version": "9.5.3",
       "resolved": "https://registry.npmjs.org/@types/jss/-/jss-9.5.3.tgz",
       "integrity": "sha512-RQWhcpOVyIhGryKpnUyZARwsgmp+tB82O7c75lC4Tjbmr3hPiCnM1wc+pJipVEOsikYXW0IHgeiQzmxQXbnAIA==",
-      "dev": true,
       "requires": {
         "csstype": "2.5.3",
         "indefinite-observable": "1.0.1"
@@ -304,7 +302,6 @@
       "version": "16.4.4",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-16.4.4.tgz",
       "integrity": "sha512-2l5CjIWQ4XsYEer09v0wsAiYJgOSRkgL3irbvMgJ3RSYy7vrkfp9wHOgXX9bpUzXbuJ4m2wcka5UZ5YZaeIXdA==",
-      "dev": true,
       "requires": {
         "csstype": "2.5.3"
       }
@@ -322,7 +319,6 @@
       "version": "2.0.11",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-2.0.11.tgz",
       "integrity": "sha512-ZLShHPYsjehQBQq1wD9EQBU1BngZOJZMTuUEipENbYPvZMt4bbLcVUaohZTilKLu0viZouadQ6mANHYynNcUOQ==",
-      "dev": true,
       "requires": {
         "@types/react": "16.4.4"
       }
@@ -656,6 +652,7 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.1.0",
@@ -763,7 +760,8 @@
     "argv": {
       "version": "0.0.2",
       "resolved": "https://registry.npmjs.org/argv/-/argv-0.0.2.tgz",
-      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas="
+      "integrity": "sha1-7L0W+JSbFXGDcRsb2jNPN4QBhas=",
+      "dev": true
     },
     "aria-query": {
       "version": "0.7.1",
@@ -859,7 +857,8 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
@@ -901,7 +900,8 @@
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -945,7 +945,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.1.1",
@@ -982,12 +983,14 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
-      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w=="
+      "integrity": "sha512-32NDda82rhwD9/JBCCkB+MRYDp0oSvlo2IL6rQWA10PQi7tDUM3eqMSltXmY+Oyl/7N3P3qNtAlv7X0d9bI28w==",
+      "dev": true
     },
     "axobject-query": {
       "version": "0.1.0",
@@ -1931,6 +1934,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -2085,8 +2089,7 @@
     "brcast": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/brcast/-/brcast-3.0.1.tgz",
-      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg==",
-      "dev": true
+      "integrity": "sha512-eI3yqf9YEqyGl9PCNTR46MGvDylGtaHjalcz6Q3fAPnP/PhpKkkve52vFdfGpwp4VUvK6LUr4TQN+2stCrEwTg=="
     },
     "brorand": {
       "version": "1.1.0",
@@ -2388,7 +2391,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -2541,8 +2545,7 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "cli-boxes": {
       "version": "1.0.0",
@@ -2639,7 +2642,8 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "coa": {
       "version": "1.0.4",
@@ -2660,6 +2664,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/codecov/-/codecov-3.0.2.tgz",
       "integrity": "sha512-9ljtIROIjPIUmMRqO+XuDITDoV8xRrZmA0jcEq6p2hg2+wY9wGmLfreAZGIL72IzUfdEDZaU8+Vjidg1fBQ8GQ==",
+      "dev": true,
       "requires": {
         "argv": "0.0.2",
         "request": "2.87.0",
@@ -2732,6 +2737,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -2890,7 +2896,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.0.5",
@@ -3090,7 +3097,6 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/css-vendor/-/css-vendor-0.3.8.tgz",
       "integrity": "sha1-ZCHP0wNM5mT+dnOXL9ARn8KJQfo=",
-      "dev": true,
       "requires": {
         "is-in-browser": "1.1.3"
       }
@@ -3175,8 +3181,7 @@
     "csstype": {
       "version": "2.5.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.5.3.tgz",
-      "integrity": "sha512-G5HnoK8nOiAq3DXIEoY2n/8Vb7Lgrms+jGJl8E4EJpQEeVONEnPFJSl8IK505wPBoxxtrtHhrRm4WX2GgdqarA==",
-      "dev": true
+      "integrity": "sha512-G5HnoK8nOiAq3DXIEoY2n/8Vb7Lgrms+jGJl8E4EJpQEeVONEnPFJSl8IK505wPBoxxtrtHhrRm4WX2GgdqarA=="
     },
     "currently-unhandled": {
       "version": "0.4.1",
@@ -3203,6 +3208,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -3222,8 +3228,7 @@
     "debounce": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.1.0.tgz",
-      "integrity": "sha512-ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ==",
-      "dev": true
+      "integrity": "sha512-ZQVKfRVlwRfD150ndzEK8M90ABT+Y/JQKs4Y7U4MXdpuoUkkrr4DwKbVux3YjylA5bUMUj0Nc3pMxPJX6N2QQQ=="
     },
     "debug": {
       "version": "2.6.9",
@@ -3279,8 +3284,7 @@
     "deepmerge": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-2.1.1.tgz",
-      "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w==",
-      "dev": true
+      "integrity": "sha512-urQxA1smbLZ2cBbXbaYObM1dJ82aJ2H57A1C/Kklfh/ZN1bgH4G/n5KWhdNfOK11W98gqZfyYj7W4frJJRwA2w=="
     },
     "default-require-extensions": {
       "version": "2.0.0",
@@ -3303,6 +3307,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
+      "dev": true,
       "requires": {
         "foreach": "2.0.5",
         "object-keys": "1.0.11"
@@ -3379,7 +3384,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -3474,8 +3480,7 @@
     "dom-helpers": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-3.3.1.tgz",
-      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg==",
-      "dev": true
+      "integrity": "sha512-2Sm+JaYn74OiTM2wHvxJOo3roiq/h25Yi69Fqk269cNUwIXsCvATB6CRSFC9Am/20G2b28hGv/+7NiWydIrPvg=="
     },
     "dom-serializer": {
       "version": "0.1.0",
@@ -3498,8 +3503,7 @@
     "dom-walk": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
-      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg=",
-      "dev": true
+      "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
     "domain-browser": {
       "version": "1.2.0",
@@ -3569,6 +3573,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
@@ -3708,6 +3713,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/enzyme-adapter-utils/-/enzyme-adapter-utils-1.3.0.tgz",
       "integrity": "sha512-vVXSt6uDv230DIv+ebCG66T1Pm36Kv+m74L1TrF4kaE7e1V7Q/LcxO0QRkajk5cA6R3uu9wJf5h13wOTezTbjA==",
+      "dev": true,
       "requires": {
         "lodash": "4.17.10",
         "object.assign": "4.1.0",
@@ -3718,6 +3724,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/enzyme-react-adapter-future/-/enzyme-react-adapter-future-1.1.3.tgz",
       "integrity": "sha512-esazh/fcYpbmw+AUXNgPAj8T5/BngHSIIS3wFM1MnA8I0jKPOVvz4ULEMwaNv6J1g7A+9d8COw3V1Z4DgpQskQ==",
+      "dev": true,
       "requires": {
         "enzyme-adapter-utils": "1.3.0",
         "lodash": "4.17.10",
@@ -3750,6 +3757,7 @@
       "version": "1.12.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.12.0.tgz",
       "integrity": "sha512-C8Fx/0jFmV5IPoMOFPA9P9G5NtqW+4cOPit3MIuvR2t7Ag2K15EJTpxnHAYTzL+aYQJIESYeXZmDBfOBE1HcpA==",
+      "dev": true,
       "requires": {
         "es-to-primitive": "1.1.1",
         "function-bind": "1.1.1",
@@ -3762,6 +3770,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
+      "dev": true,
       "requires": {
         "is-callable": "1.1.3",
         "is-date-object": "1.0.1",
@@ -4282,7 +4291,8 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "extend-shallow": {
       "version": "3.0.2",
@@ -4328,12 +4338,14 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.2",
@@ -4658,7 +4670,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -4869,17 +4882,20 @@
     "foreach": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
-      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k=",
+      "dev": true
     },
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
@@ -5493,7 +5509,8 @@
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+      "dev": true
     },
     "function.prototype.name": {
       "version": "1.1.0",
@@ -5534,6 +5551,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       }
@@ -5587,7 +5605,6 @@
       "version": "4.3.2",
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
-      "dev": true,
       "requires": {
         "min-document": "2.19.0",
         "process": "0.5.2"
@@ -5685,12 +5702,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -5700,6 +5719,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
       "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dev": true,
       "requires": {
         "function-bind": "1.1.1"
       }
@@ -5722,7 +5742,8 @@
     "has-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.0.tgz",
-      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q="
+      "integrity": "sha1-uhqPGvKg/DllD1yFA2dwQSIGO0Q=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -5879,6 +5900,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -5900,8 +5922,7 @@
     "hyphenate-style-name": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/hyphenate-style-name/-/hyphenate-style-name-1.0.2.tgz",
-      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es=",
-      "dev": true
+      "integrity": "sha1-MRYKNpMK2vH8BMYHT360FGXU7Es="
     },
     "iconv-lite": {
       "version": "0.4.23",
@@ -6014,7 +6035,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indefinite-observable/-/indefinite-observable-1.0.1.tgz",
       "integrity": "sha1-CZFUI8yNb36xy3iCrRNGM8mm7cM=",
-      "dev": true,
       "requires": {
         "symbol-observable": "1.0.4"
       },
@@ -6022,8 +6042,7 @@
         "symbol-observable": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.4.tgz",
-          "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0=",
-          "dev": true
+          "integrity": "sha1-Kb9hXUqnEhvdiYsi1LP5vE4qoD0="
         }
       }
     },
@@ -6213,7 +6232,8 @@
     "is-callable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.3.tgz",
-      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI="
+      "integrity": "sha1-hut1OSgF3cM69xySoO7fdO52BLI=",
+      "dev": true
     },
     "is-ci": {
       "version": "1.1.0",
@@ -6236,7 +6256,8 @@
     "is-date-object": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-date-object/-/is-date-object-1.0.1.tgz",
-      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY="
+      "integrity": "sha1-mqIOtq7rv/d/vTPnTKAbM1gdOhY=",
+      "dev": true
     },
     "is-descriptor": {
       "version": "0.1.6",
@@ -6308,8 +6329,7 @@
     "is-function": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.1.tgz",
-      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU=",
-      "dev": true
+      "integrity": "sha1-Es+5i2W1fdPRk6MSH19uL0N2ArU="
     },
     "is-glob": {
       "version": "2.0.1",
@@ -6323,8 +6343,7 @@
     "is-in-browser": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
-      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU=",
-      "dev": true
+      "integrity": "sha1-Vv9NtoOgeMYILrldrX3GLh0E+DU="
     },
     "is-installed-globally": {
       "version": "0.1.0",
@@ -6420,7 +6439,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "dev": true,
       "requires": {
         "isobject": "3.0.1"
       }
@@ -6453,6 +6471,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
+      "dev": true,
       "requires": {
         "has": "1.0.3"
       }
@@ -6498,12 +6517,14 @@
     "is-symbol": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.1.tgz",
-      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI="
+      "integrity": "sha1-PMWfAAJRlLarLjjbrmaJJWtmBXI=",
+      "dev": true
     },
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -6532,8 +6553,7 @@
     "isobject": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
-      "dev": true
+      "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8="
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
@@ -6547,7 +6567,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "issue-regex": {
       "version": "1.0.0",
@@ -7385,6 +7406,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -7443,12 +7465,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -7468,7 +7492,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
@@ -7495,6 +7520,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -7506,7 +7532,6 @@
       "version": "9.8.7",
       "resolved": "https://registry.npmjs.org/jss/-/jss-9.8.7.tgz",
       "integrity": "sha512-awj3XRZYxbrmmrx9LUSj5pXSUfm12m8xzi/VKeqI1ZwWBtQ0kVPTs3vYs32t4rFw83CgFDukA8wKzOE9sMQnoQ==",
-      "dev": true,
       "requires": {
         "is-in-browser": "1.1.3",
         "symbol-observable": "1.2.0",
@@ -7517,7 +7542,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
           }
@@ -7528,7 +7552,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jss-camel-case/-/jss-camel-case-6.1.0.tgz",
       "integrity": "sha512-HPF2Q7wmNW1t79mCqSeU2vdd/vFFGpkazwvfHMOhPlMgXrJDzdj9viA2SaHk9ZbD5pfL63a8ylp4++irYbbzMQ==",
-      "dev": true,
       "requires": {
         "hyphenate-style-name": "1.0.2"
       }
@@ -7537,7 +7560,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/jss-compose/-/jss-compose-5.0.0.tgz",
       "integrity": "sha512-YofRYuiA0+VbeOw0VjgkyO380sA4+TWDrW52nSluD9n+1FWOlDzNbgpZ/Sb3Y46+DcAbOS21W5jo6SAqUEiuwA==",
-      "dev": true,
       "requires": {
         "warning": "3.0.0"
       },
@@ -7546,7 +7568,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
           }
@@ -7556,20 +7577,17 @@
     "jss-default-unit": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/jss-default-unit/-/jss-default-unit-8.0.2.tgz",
-      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg==",
-      "dev": true
+      "integrity": "sha512-WxNHrF/18CdoAGw2H0FqOEvJdREXVXLazn7PQYU7V6/BWkCV0GkmWsppNiExdw8dP4TU1ma1dT9zBNJ95feLmg=="
     },
     "jss-expand": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/jss-expand/-/jss-expand-5.3.0.tgz",
-      "integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg==",
-      "dev": true
+      "integrity": "sha512-NiM4TbDVE0ykXSAw6dfFmB1LIqXP/jdd0ZMnlvlGgEMkMt+weJIl8Ynq1DsuBY9WwkNyzWktdqcEW2VN0RAtQg=="
     },
     "jss-extend": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/jss-extend/-/jss-extend-6.2.0.tgz",
       "integrity": "sha512-YszrmcB6o9HOsKPszK7NeDBNNjVyiW864jfoiHoMlgMIg2qlxKw70axZHqgczXHDcoyi/0/ikP1XaHDPRvYtEA==",
-      "dev": true,
       "requires": {
         "warning": "3.0.0"
       },
@@ -7578,7 +7596,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
           }
@@ -7588,14 +7605,12 @@
     "jss-global": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/jss-global/-/jss-global-3.0.0.tgz",
-      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q==",
-      "dev": true
+      "integrity": "sha512-wxYn7vL+TImyQYGAfdplg7yaxnPQ9RaXY/cIA8hawaVnmmWxDHzBK32u1y+RAvWboa3lW83ya3nVZ/C+jyjZ5Q=="
     },
     "jss-nested": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/jss-nested/-/jss-nested-6.0.1.tgz",
       "integrity": "sha512-rn964TralHOZxoyEgeq3hXY8hyuCElnvQoVrQwKHVmu55VRDd6IqExAx9be5HgK0yN/+hQdgAXQl/GUrBbbSTA==",
-      "dev": true,
       "requires": {
         "warning": "3.0.0"
       },
@@ -7604,7 +7619,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
           }
@@ -7615,7 +7629,6 @@
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/jss-preset-default/-/jss-preset-default-4.5.0.tgz",
       "integrity": "sha512-qZbpRVtHT7hBPpZEBPFfafZKWmq3tA/An5RNqywDsZQGrlinIF/mGD9lmj6jGqu8GrED2SMHZ3pPKLmjCZoiaQ==",
-      "dev": true,
       "requires": {
         "jss-camel-case": "6.1.0",
         "jss-compose": "5.0.0",
@@ -7632,14 +7645,12 @@
     "jss-props-sort": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/jss-props-sort/-/jss-props-sort-6.0.0.tgz",
-      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g==",
-      "dev": true
+      "integrity": "sha512-E89UDcrphmI0LzmvYk25Hp4aE5ZBsXqMWlkFXS0EtPkunJkRr+WXdCNYbXbksIPnKlBenGB9OxzQY+mVc70S+g=="
     },
     "jss-template": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/jss-template/-/jss-template-1.0.1.tgz",
       "integrity": "sha512-m5BqEWha17fmIVXm1z8xbJhY6GFJxNB9H68GVnCWPyGYfxiAgY9WTQyvDAVj+pYRgrXSOfN5V1T4+SzN1sJTeg==",
-      "dev": true,
       "requires": {
         "warning": "3.0.0"
       },
@@ -7648,7 +7659,6 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/warning/-/warning-3.0.0.tgz",
           "integrity": "sha1-MuU3fLVy3kqwR1O9+IIcAe1gW3w=",
-          "dev": true,
           "requires": {
             "loose-envify": "1.3.1"
           }
@@ -7659,7 +7669,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/jss-vendor-prefixer/-/jss-vendor-prefixer-7.0.0.tgz",
       "integrity": "sha512-Agd+FKmvsI0HLcYXkvy8GYOw3AAASBUpsmIRvVQheps+JWaN892uFOInTr0DRydwaD91vSSUCU4NssschvF7MA==",
-      "dev": true,
       "requires": {
         "css-vendor": "0.3.8"
       }
@@ -7676,8 +7685,7 @@
     "keycode": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/keycode/-/keycode-2.2.0.tgz",
-      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ=",
-      "dev": true
+      "integrity": "sha1-PQr1bce4uOXLqNCpfxByBO7CKwQ="
     },
     "kind-of": {
       "version": "3.2.2",
@@ -7961,7 +7969,8 @@
     "lodash": {
       "version": "4.17.10",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg==",
+      "dev": true
     },
     "lodash.camelcase": {
       "version": "4.3.0",
@@ -8390,12 +8399,14 @@
     "mime-db": {
       "version": "1.33.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
-      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ=="
+      "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.18",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
+      "dev": true,
       "requires": {
         "mime-db": "1.33.0"
       }
@@ -8410,7 +8421,6 @@
       "version": "2.19.0",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
-      "dev": true,
       "requires": {
         "dom-walk": "0.1.1"
       }
@@ -8721,8 +8731,7 @@
     "normalize-scroll-left": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/normalize-scroll-left/-/normalize-scroll-left-0.1.2.tgz",
-      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg==",
-      "dev": true
+      "integrity": "sha512-F9YMRls0zCF6BFIE2YnXDRpHPpfd91nOIaNdDgrx5YMoPLo8Wqj+6jNXHQsYBavJeXP4ww8HCt0xQAKc5qk2Fg=="
     },
     "normalize-url": {
       "version": "1.9.1",
@@ -8950,7 +8959,8 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
@@ -8994,7 +9004,8 @@
     "object-keys": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0="
+      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "dev": true
     },
     "object-visit": {
       "version": "1.0.1",
@@ -9009,6 +9020,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
       "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
@@ -9051,6 +9063,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.0.4.tgz",
       "integrity": "sha1-5STaCbT2b/Bd9FdUbscqyZ8TBpo=",
+      "dev": true,
       "requires": {
         "define-properties": "1.1.2",
         "es-abstract": "1.12.0",
@@ -9418,7 +9431,8 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -9480,8 +9494,7 @@
     "popper.js": {
       "version": "1.14.3",
       "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.14.3.tgz",
-      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU=",
-      "dev": true
+      "integrity": "sha1-FDj5jQRqz3tNeM1QK/QYrGTU8JU="
     },
     "posix-character-classes": {
       "version": "0.1.1",
@@ -10098,8 +10111,7 @@
     "process": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/process/-/process-0.5.2.tgz",
-      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8=",
-      "dev": true
+      "integrity": "sha1-FjjYqONML0QKkduVq5rrZ3/Bhc8="
     },
     "process-nextick-args": {
       "version": "2.0.0",
@@ -10201,7 +10213,8 @@
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -10212,7 +10225,8 @@
     "qs": {
       "version": "6.5.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+      "dev": true
     },
     "query-string": {
       "version": "4.3.4",
@@ -10255,7 +10269,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/rafl/-/rafl-1.2.2.tgz",
       "integrity": "sha1-/pMPdYIRAg1H44gV9Rlqi+QVB0A=",
-      "dev": true,
       "requires": {
         "global": "4.3.2"
       }
@@ -10427,13 +10440,13 @@
     "react-is": {
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.4.0.tgz",
-      "integrity": "sha512-8ADZg/mBw+t2Fbr5Hm1K64v8q8Q6E+DprV5wQ5A8PSLW6XP0XJFMdUskVEW8efQ5oUgWHn8EYdHEPAMF0Co6hA=="
+      "integrity": "sha512-8ADZg/mBw+t2Fbr5Hm1K64v8q8Q6E+DprV5wQ5A8PSLW6XP0XJFMdUskVEW8efQ5oUgWHn8EYdHEPAMF0Co6hA==",
+      "dev": true
     },
     "react-jss": {
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/react-jss/-/react-jss-8.6.0.tgz",
       "integrity": "sha512-AraNxzf1r9rhWY7uByMIKdOTCqQEP5wvYb5wp6ubhl3g8t+b2daQyuL0TfRZnd/xxmH92REHJhsAdV9APvHUlQ==",
-      "dev": true,
       "requires": {
         "hoist-non-react-statics": "2.5.4",
         "jss": "9.8.7",
@@ -10451,7 +10464,6 @@
       "version": "0.10.4",
       "resolved": "https://registry.npmjs.org/react-popper/-/react-popper-0.10.4.tgz",
       "integrity": "sha1-rypBXqIike3VBGeNev2opu4ylao=",
-      "dev": true,
       "requires": {
         "popper.js": "1.14.3",
         "prop-types": "15.6.2"
@@ -10461,6 +10473,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/react-reconciler/-/react-reconciler-0.7.0.tgz",
       "integrity": "sha512-50JwZ3yNyMS8fchN+jjWEJOH3Oze7UmhxeoJLn2j6f3NjpfCRbcmih83XTWmzqtar/ivd5f7tvQhvvhism2fgg==",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.17",
         "loose-envify": "1.3.1",
@@ -10472,6 +10485,7 @@
       "version": "16.4.0",
       "resolved": "https://registry.npmjs.org/react-test-renderer/-/react-test-renderer-16.4.0.tgz",
       "integrity": "sha512-Seh1t9xFY6TKiV/hRlPzUkqX1xHOiKIMsctfU0cggo1ajsLjoIJFL520LlrxV+4/VIj+clrCeH6s/aVv/vTStg==",
+      "dev": true,
       "requires": {
         "fbjs": "0.8.17",
         "object-assign": "4.1.1",
@@ -10491,7 +10505,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.4.0.tgz",
       "integrity": "sha512-Xv5d55NkJUxUzLCImGSanK8Cl/30sgpOEMGc5m86t8+kZwrPxPCPcFqyx83kkr+5Lz5gs6djuvE5By+gce+VjA==",
-      "dev": true,
       "requires": {
         "dom-helpers": "3.3.1",
         "loose-envify": "1.3.1",
@@ -10766,6 +10779,7 @@
       "version": "2.87.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
       "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.7.0",
@@ -10793,6 +10807,7 @@
           "version": "2.3.4",
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
           "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
           "requires": {
             "punycode": "1.4.1"
           }
@@ -11153,7 +11168,8 @@
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -11524,7 +11540,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/scroll/-/scroll-2.0.3.tgz",
       "integrity": "sha512-3ncZzf8gUW739h3LeS68nSssO60O+GGjT3SxzgofQmT8PIoyHzebql9HHPJopZX8iT6TKOdwaWFMqL6LzUN3DQ==",
-      "dev": true,
       "requires": {
         "rafl": "1.2.2"
       }
@@ -12185,6 +12200,7 @@
       "version": "1.14.2",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
       "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -12875,7 +12891,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/theming/-/theming-1.3.0.tgz",
       "integrity": "sha512-ya5Ef7XDGbTPBv5ENTwrwkPUexrlPeiAg/EI9kdlUAZhNlRbCdhMKRgjNX1IcmsmiPcqDQZE6BpSaH+cr31FKw==",
-      "dev": true,
       "requires": {
         "brcast": "3.0.1",
         "is-function": "1.0.1",
@@ -13039,6 +13054,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.2"
       }
@@ -13047,6 +13063,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -13405,7 +13422,8 @@
     "urlgrey": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/urlgrey/-/urlgrey-0.4.4.tgz",
-      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8="
+      "integrity": "sha1-iS/pWWCAXoVRnxzUOJ8stMu3ZS8=",
+      "dev": true
     },
     "use": {
       "version": "3.1.0",
@@ -13454,7 +13472,8 @@
     "uuid": {
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA=="
+      "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+      "dev": true
     },
     "v8flags": {
       "version": "2.1.1",
@@ -13491,6 +13510,7 @@
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",

--- a/lib/package.json
+++ b/lib/package.json
@@ -32,8 +32,6 @@
     "email": "dmtr.kovalenko@outlook.com"
   },
   "peerDependencies": {
-    "classnames": "^2.2.5",
-    "@material-ui/core": "^1.0.0-rc.0",
     "prop-types": "^15.6.0",
     "react": "^16.3.0",
     "react-dom": "^16.3.0"
@@ -44,8 +42,9 @@
     "luxon": "^1.0.0"
   },
   "dependencies": {
-    "codecov": "^3.0.2",
-    "enzyme-react-adapter-future": "^1.1.3",
+    "@material-ui/core": "^1.3.0",
+    "classnames": "^2.2.5",
+    "keycode": "^2.2.0",
     "react-event-listener": "^0.6.1",
     "react-text-mask": "=5.4.1",
     "recompose": "^0.27.1"
@@ -79,7 +78,6 @@
     "postinstall": "node -e \"console.log('\\u001b[35m\\u001b[1mHave you installed one of peer libraries?\\u001b[22m\\u001b[39m\\n > date-fns \\n > luxon \\n > moment')\""
   },
   "devDependencies": {
-    "@material-ui/core": "^1.3.0",
     "@types/classnames": "^2.2.3",
     "@types/jest": "^22.2.3",
     "@types/jss": "^9.5.2",
@@ -103,11 +101,12 @@
     "babel-preset-env": "^1.5.1",
     "babel-preset-es2015": "^6.24.1",
     "babel-preset-latest": "^6.24.1",
-    "classnames": "^2.2.5",
+    "codecov": "^3.0.2",
     "cross-env": "^5.2.0",
     "date-fns": "2.0.0-alpha.7",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.0",
+    "enzyme-react-adapter-future": "^1.1.3",
     "eslint": "^4.19.1",
     "eslint-config-airbnb": "^16.0.0",
     "eslint-plugin-import": "^2.13.0",

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -8,29 +8,57 @@ import pkg from './package.json';
 const external = id =>
   !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/');
 
-export default {
-  input: './src/index.js',
-  output: [
-    { file: pkg.main, format: 'cjs', sourcemap: true },
-    { file: pkg.module, format: 'esm', sourcemap: true },
-  ],
-  external,
-  plugins: [
-    resolve({
-      extensions: ['.js', '.jsx'],
-    }),
-    babel({
-      exclude: 'node_modules/**',
-      plugins: ['external-helpers'],
-    }),
-    commonjs({
-      include: [
-        'node_modules/**',
-      ],
-      namedExports: {
-        'node_modules/moment-range/dist/moment-range.js': ['extendMoment'],
-      },
-    }),
-    sizeSnapshot()
-  ],
-};
+const resolveOptions = {
+  extensions: ['.js', '.jsx']
+}
+
+const getBabelOptions = () => ({
+  exclude: 'node_modules/**',
+  plugins: ['external-helpers']
+})
+
+const globals = {
+  'react': 'React',
+  'react-dom': 'ReactDOM',
+  'prop-types': 'PropTypes',
+}
+
+export default [
+  {
+    input: './src/index.js',
+    output: {
+      file: 'build/dist/material-ui-pickers.umd.js',
+      format: 'umd',
+      name: 'material-ui-pickers',
+      globals
+    },
+    external: Object.keys(globals),
+    plugins: [
+      resolve(resolveOptions),
+      babel(getBabelOptions()),
+      commonjs({
+        include: [
+          'node_modules/**',
+        ],
+        namedExports: {
+          'node_modules/moment-range/dist/moment-range.js': ['extendMoment'],
+        },
+      }),
+      sizeSnapshot()
+    ],
+  },
+
+  {
+    input: './src/index.js',
+    output: [
+      { file: pkg.main, format: 'cjs', sourcemap: true },
+      { file: pkg.module, format: 'esm', sourcemap: true },
+    ],
+    external,
+    plugins: [
+      resolve(resolveOptions),
+      babel(getBabelOptions()),
+      sizeSnapshot()
+    ],
+  }
+];


### PR DESCRIPTION
Ref https://github.com/dmtrKovalenko/material-ui-pickers/issues/503

In this diff I added umd bundle. Dependencies was slightly shaked
to simplify distribution and consuming.

`classnames` is too small project to be peer dependency. As a regular
one it will introduce less noise.

material-ui is published as stable and there is not need to keep it as
peer. Moreover it's not possible to keep it as external package in umd
because of path fragmentation.

Removed codecov and enzyme from direct dependencies.

This package will be available in `window` object under `material-ui-pickers`
namespace similar to `material-ui` one.

`keycode` is added explicitly as a direct dependency.

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 