### PR TITLE
#517 Add `mergeDateAndTime` to the utils and use it from <Calendar/>

### DIFF
--- a/lib/src/DatePicker/Calendar.jsx
+++ b/lib/src/DatePicker/Calendar.jsx
@@ -77,11 +77,7 @@ export class Calendar extends Component {
 
   onDateSelect = (day, isFinish = true) => {
     const { date, utils } = this.props;
-
-    const withHours = utils.setHours(day, utils.getHours(date));
-    const withMinutes = utils.setMinutes(withHours, utils.getMinutes(date));
-
-    this.props.onChange(withMinutes, isFinish);
+    this.props.onChange(utils.mergeDateAndTime(day, date), isFinish);
   };
 
   handleChangeMonth = (newMonth) => {

--- a/lib/src/typings/utils.d.ts
+++ b/lib/src/typings/utils.d.ts
@@ -35,6 +35,7 @@ export class Utils<TDate> {
   getMonth(value: TDate): number;
   getYear(value: TDate): number;
   setYear(value: TDate, count: number): TDate;
+  mergeDateAndTime(date: TDate, time: TDate): TDate;
 
   getStartOfMonth(value: TDate): TDate;
   getNextMonth(value: TDate): TDate;

--- a/lib/src/utils/date-fns-utils.js
+++ b/lib/src/utils/date-fns-utils.js
@@ -139,6 +139,10 @@ export default class DateFnsUtils {
 
   setYear = setYear;
 
+  mergeDateAndTime(date, time) {
+    return this.setMinutes(this.setHours(date, this.getHours(time)), this.getMinutes(time));
+  }
+
   getWeekdays() {
     const now = new Date();
     return eachDayOfInterval(

--- a/lib/src/utils/luxon-utils.js
+++ b/lib/src/utils/luxon-utils.js
@@ -136,6 +136,10 @@ export default class LuxonUtils {
     return value.set({ year });
   }
 
+  mergeDateAndTime(date, time) {
+    return this.setMinutes(this.setHours(date, this.getHours(time)), this.getMinutes(time));
+  }
+
   getStartOfMonth(value) {
     return value.startOf('month');
   }

--- a/lib/src/utils/moment-utils.js
+++ b/lib/src/utils/moment-utils.js
@@ -129,6 +129,10 @@ export default class MomentUtils {
     return date.clone().set('year', year);
   }
 
+  mergeDateAndTime(date, time) {
+    return this.setMinutes(this.setHours(date, this.getHours(time)), this.getMinutes(time));
+  }
+
   getWeekdays() {
     return [0, 1, 2, 3, 4, 5, 6].map(dayOfWeek => this.moment().weekday(dayOfWeek).format('dd')[0]);
   }


### PR DESCRIPTION
- [x] I have changed my target branch to **develop** :facepunch: 

## Note
On my machine, even on the `master` or `develop` branch, the unit tests are failing. That's probably due to my weird Windows+WSL+IDE setup. So I'm sending this pull request early, hoping that Travis CI will run the tests properly. Also, the tests were not run automatically with `git commit` as promised in the documentation.

Note that this commit does not directly address the support of "time-less dates" as discussed in #517. It seems to me that there is no interest in having that functionality directly in the library. Instead, the change makes the library more extensible to allow users to implement this and other use cases themselves.
Let me know what you think.

## Commit Description
Currently, the Calendar.onDateSelect() handler simply calls setHours() and setMinutes() to carry over the time information from the previous value to the new date-only value selected in the Calendar. This commit adds a function `mergeDateAndTime` to the date utils, which defaults to this behavior, but allows the user to customize how the time information is carried over. One use case is carrying over the seconds in addition. Another use case is values that do not have any time information, in which case there is nothing to carry over.