### PR TITLE
Improve babel output

### DIFF
--- a/lib/.babelrc
+++ b/lib/.babelrc
@@ -1,11 +1,11 @@
 {
   "presets": [
-    ["@babel/env", { "modules": false }],
+    ["@babel/env", { "modules": false, "loose": true }],
     "@babel/react"
   ],
   "plugins": [
-    "@babel/proposal-object-rest-spread",
-    "@babel/proposal-class-properties"
+    ["@babel/proposal-object-rest-spread", { "loose": true }],
+    ["@babel/proposal-class-properties", { "loose": true }]
   ],
   "env": {
     "test": {

--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,31 +1,21 @@
 {
-  "build/dist/material-ui-pickers.cjs.js": {
-    "bundled": 118638,
-    "minified": 70395,
-    "gzipped": 14046
-  },
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 116289,
-    "minified": 68268,
-    "gzipped": 13912,
+    "bundled": 107325,
+    "minified": 60691,
+    "gzipped": 13510,
     "treeshaked": {
       "rollup": {
-        "code": 54349,
-        "import_statements": 1790
+        "code": 52207,
+        "import_statements": 1464
       },
       "webpack": {
-        "code": 58895
+        "code": 55835
       }
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 842918,
-    "minified": 335876,
-    "gzipped": 84023
-  },
-  "build/dist/material-ui-pickers.umd.min.js": {
-    "bundled": 842918,
-    "minified": 335876,
-    "gzipped": 84023
+    "bundled": 849799,
+    "minified": 330878,
+    "gzipped": 84001
   }
 }

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -16,13 +16,13 @@ const globals = {
   'prop-types': 'PropTypes',
 };
 
-const babelOptions = {
+const getBabelOptions = ({ useESModules }) => ({
   exclude: 'node_modules/**',
   runtimeHelpers: true,
   plugins: [
-    "@babel/transform-runtime"
+    ["@babel/transform-runtime", { useBuiltIns: true, useESModules }]
   ]
-};
+});
 
 const commonjsOptions = {
   include: 'node_modules/**',
@@ -35,13 +35,20 @@ export default [
   {
     input,
     external,
-    output: [
-      { file: pkg.main, format: 'cjs', sourcemap: true },
-      { file: pkg.module, format: 'esm', sourcemap: true },
-    ],
+    output: { file: pkg.main, format: 'cjs', sourcemap: true },
     plugins: [
       resolve({ extensions: ['.js', '.jsx'] }),
-      babel(babelOptions),
+      babel(getBabelOptions({ useESModules: false })),
+    ],
+  },
+
+  {
+    input,
+    external,
+    output: { file: pkg.module, format: 'esm', sourcemap: true },
+    plugins: [
+      resolve({ extensions: ['.js', '.jsx'] }),
+      babel(getBabelOptions({ useESModules: true })),
       commonjs(commonjsOptions),
       sizeSnapshot(),
     ],
@@ -59,7 +66,7 @@ export default [
     },
     plugins: [
       resolve({ extensions: ['.js', '.jsx'] }),
-      babel(babelOptions),
+      babel(getBabelOptions({ useESModules: true })),
       commonjs(commonjsOptions),
       sizeSnapshot(),
     ],
@@ -76,9 +83,8 @@ export default [
     },
     plugins: [
       resolve({ extensions: ['.js', '.jsx'] }),
-      babel(babelOptions),
+      babel(getBabelOptions({ useESModules: true })),
       commonjs(commonjsOptions),
-      sizeSnapshot(),
       uglify(),
     ],
   },


### PR DESCRIPTION
In this diff I enabled loose mode and used esm and builtin versions
of helpers which slightly reduced generated code size.

Remove size snapshots from minified umd which is equal to umd snapshot
and from cjs bundle which is almost equal to esm one.

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 