### PR TITLE
#517 Add `ViewContainerComponent` prop to `<DateTimePicker/>`

### DIFF
--- a/lib/src/DateTimePicker/DateTimePicker.jsx
+++ b/lib/src/DateTimePicker/DateTimePicker.jsx
@@ -36,6 +36,8 @@ export class DateTimePicker extends Component {
     showTabs: PropTypes.bool,
     timeIcon: PropTypes.node,
     utils: PropTypes.object.isRequired,
+    ViewContainerComponent:
+      PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.object]),
   }
 
   static defaultProps = {
@@ -52,6 +54,7 @@ export class DateTimePicker extends Component {
     shouldDisableDate: undefined,
     showTabs: true,
     timeIcon: undefined,
+    ViewContainerComponent: 'div',
   }
 
   state = {
@@ -120,7 +123,11 @@ export class DateTimePicker extends Component {
       animateYearScrolling,
       classes,
       allowKeyboardControl,
+      ViewContainerComponent,
     } = this.props;
+
+    const ViewContainerComponentProps = typeof ViewContainerComponent === 'string'
+      ? {} : { openView, onChange: this.onChange };
 
     return (
       <Fragment>
@@ -144,7 +151,7 @@ export class DateTimePicker extends Component {
             />
         }
 
-        <div className={classes.viewContainer}>
+        <ViewContainerComponent className={classes.viewContainer} {...ViewContainerComponentProps}>
           <View selected={openView === viewType.YEAR}>
             <YearSelection
               date={date}
@@ -183,7 +190,7 @@ export class DateTimePicker extends Component {
               onSecondsChange={this.handleChange}
             />
           </View>
-        </div>
+        </ViewContainerComponent>
       </Fragment>
     );
   }


### PR DESCRIPTION
- [x] I have changed my target branch to **develop**

## Commit description
This allows users of the component to customize the implementation and add additional `View`s or other UI elements. When users supply a React.Component instead of just a DOM element (specified as a string), then the `openView` and `onChange` properties get passed to the component's implementation.

## Context
This is the particular change I am using to make `material-ui-pickers` extensible enough, such that my application can implement time-less dates (see #517) on top of it.
A whole series of similar changes is thinkable (and I'm happy to implement them consistently with this one):

- Add `DateTimePickerTabsComponent`, `YearSelectionComponent`, `CalendarComponent`, and so on to this class. They default to the shipped components, but allow the user to customize individual parts. Similarly, add `XyzComponent` properties to other container components in the library. This is analogous to, for example, the `Avatar.component` prop (see [here](https://material-ui.com/api/avatar/#props)).
- Add `CalendarProps`, `YearSelectionProps` ... `XyzProps`, which are objects that are passed directly as props into the respective child component, similar to `TextField.InputLabelProps` (see [here](https://material-ui.com/api/text-field/#props)) in core `material-ui`.

Both these proposed changes are in line with the API design of `@material-ui/core`. In combination, they could be used like this to modify the look and/or behavior of sub-components in a targeted way:

```
class MyCustomDateTimePicker extends React.Component { ... }
class MyCustomDateTextField extends React.Component { ... }
...
<DateTimePickerWrapper value={...} format="..."
    DateTimePickerComponent={MyCustomDateTimePicker}
    ModalWrapperProps={{TextFieldComponent: MyCustomDateTextField}}/>
```

## Note
As with #518 already, I could not run the unit tests because they generally don't work on my machine. I'm again relying on Travis CI to run the tests properly.