### PR TITLE
Bug: Fix Patreon Avatar External Linking

### DIFF
--- a/docs/src/Routes/Landing/components/PatreonSponsors.jsx
+++ b/docs/src/Routes/Landing/components/PatreonSponsors.jsx
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'react-router-dom';
 
 import { withStyles, Avatar, List, ListItem, ListItemText } from '@material-ui/core';
 import patrons from '../../../../patrons.json';
@@ -21,17 +20,16 @@ class PatreonSponsors extends Component {
       <List className={classes.patronList}>
         {
           patrons.map(patron => (
-            <Link
+            <a
               key={patron.full_name}
-              to={patron.url}
-              target="_blank"
+              href={patron.url}
               rel="noopenner noreferrer"
             >
               <ListItem button>
                 <Avatar alt={patron.full_name} src={patron.image_url} />
                 <ListItemText primary={patron.full_name} secondary={patron.email} />
               </ListItem>
-            </Link>
+            </a>
           ))
         }
       </List>


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

<!-- Checked checkbox should look like this - [x] -->
<!-- If you are changing just the docs you can create PR directly to master -->
- [x] I have changed my target branch to **develop** :facepunch: 

### Closes # <!-- Please refer issue number here, if exists -->

## Description
`<Link>` is only used for internal app routing and not needed, a simple `<a>` tag should be sufficient for this. For the Pateron avatars, it's intended to link to their Pateron page but in current state it's appending the url onto the current url. You can test this by clicking on the Patreon avatars at the bottom of the [firebase home page
](https://material-ui-pickers.firebaseapp.com/)

See comment in this issue about `<Link>` internal routing [here](https://github.com/ReactTraining/react-router/pull/2193)