### PR TITLE
Use index as key for weekdays

### DIFF
--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -61,7 +61,7 @@ export const CalendarHeader = ({
         {
           utils.getWeekdays().map((day, index) => (
             <Typography
-              key={index}
+              key={index} // eslint-disable-line react/no-array-index-key
               variant="caption"
               className={classes.dayLabel}
             >

--- a/lib/src/DatePicker/CalendarHeader.jsx
+++ b/lib/src/DatePicker/CalendarHeader.jsx
@@ -59,9 +59,9 @@ export const CalendarHeader = ({
 
       <div className={classes.daysHeader}>
         {
-          utils.getWeekdays().map(day => (
+          utils.getWeekdays().map((day, index) => (
             <Typography
-              key={day}
+              key={index}
               variant="caption"
               className={classes.dayLabel}
             >


### PR DESCRIPTION
The luxon utils return single-character weekdays, which gives us duplicate keys
T and S.