### PR TITLE
fix(deps): update recompose and event-listener to resolve issues with babel.56

### DIFF
--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -5,22 +5,22 @@
     "gzipped": 14193
   },
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 107630,
-    "minified": 60799,
-    "gzipped": 13539,
+    "bundled": 108402,
+    "minified": 61138,
+    "gzipped": 13631,
     "treeshaked": {
       "rollup": {
-        "code": 52307,
-        "import_statements": 1464
+        "code": 52611,
+        "import_statements": 1462
       },
       "webpack": {
-        "code": 55937
+        "code": 56251
       }
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 850098,
-    "minified": 330978,
-    "gzipped": 84033
+    "bundled": 855493,
+    "minified": 333237,
+    "gzipped": 83900
   }
 }

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -3318,6 +3318,20 @@
             "prop-types": "^15.6.2",
             "react-lifecycles-compat": "^3.0.4"
           }
+        },
+        "recompose": {
+          "version": "0.27.1",
+          "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.1.tgz",
+          "integrity": "sha512-p7xsyi/rfNjHfdP7vPU02uSFa+Q1eHhjKrvO+3+kRP4Ortj+MxEmpmd+UQtBGM2D2iNAjzNI5rCyBKp9Ob5McA==",
+          "dev": true,
+          "requires": {
+            "babel-runtime": "^6.26.0",
+            "change-emitter": "^0.1.2",
+            "fbjs": "^0.8.1",
+            "hoist-non-react-statics": "^2.3.1",
+            "react-lifecycles-compat": "^3.0.2",
+            "symbol-observable": "^1.0.4"
+          }
         }
       }
     },
@@ -4228,6 +4242,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "^2.4.0",
         "regenerator-runtime": "^0.11.0"
@@ -7832,7 +7847,10 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.2.1.tgz",
       "integrity": "sha512-E2s1b4GVbt8PyG+iaRN6ks8N0Oy2LOJz7SIMUwWWWx7Mr5Z08hKkfpkKQbOtOGqzkFpckDJHjjZ8qfigN2W86A==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.60.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -8288,6 +8306,12 @@
       "requires": {
         "postcss": "^6.0.1"
       }
+    },
+    "icu4c-data": {
+      "version": "0.60.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.60.2.tgz",
+      "integrity": "sha512-4ScORTYJPIDJRPtAkQWXfKqGk8u1ThOxFWCJ3jkq+rj/MU4cK6isCvhFiEjunivw1/bJ10LqNAaJ9pAK68DEZg==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.12",
@@ -12236,13 +12260,24 @@
       }
     },
     "react-event-listener": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.1.tgz",
-      "integrity": "sha1-QceoCmazmMJ91RHiJxKwLz1OzMo=",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/react-event-listener/-/react-event-listener-0.6.2.tgz",
+      "integrity": "sha512-/7s5VF+eR/LRDnGcYyiBJcNXjjCFoCo8UlX+Bn6417WMneV2f82zG1/HfCoEH6PBHqEPk3CPkMmuTDz80pzRXw==",
       "requires": {
-        "@babel/runtime": "^7.0.0-beta.42",
+        "@babel/runtime": "7.0.0-beta.42",
         "prop-types": "^15.6.0",
         "warning": "^4.0.1"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.0.0-beta.42",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.42.tgz",
+          "integrity": "sha512-iOGRzUoONLOtmCvjUsZv3mZzgCT6ljHQY5fr1qG1QIiJQwtM7zbPWGGpa3QWETq+UqwWyJnoi5XZDZRwZDFciQ==",
+          "requires": {
+            "core-js": "^2.5.3",
+            "regenerator-runtime": "^0.11.1"
+          }
+        }
       }
     },
     "react-is": {
@@ -12393,16 +12428,31 @@
       }
     },
     "recompose": {
-      "version": "0.27.1",
-      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.27.1.tgz",
-      "integrity": "sha512-p7xsyi/rfNjHfdP7vPU02uSFa+Q1eHhjKrvO+3+kRP4Ortj+MxEmpmd+UQtBGM2D2iNAjzNI5rCyBKp9Ob5McA==",
+      "version": "0.28.2",
+      "resolved": "https://registry.npmjs.org/recompose/-/recompose-0.28.2.tgz",
+      "integrity": "sha512-baVNKQBQAAAuLRnv6Cb/6/j59a1BVj6c6Pags1KXVyRB0yPfQVUZtuAUnqHDBXoR8iXPrLGWE4RNtCQ/AaRP3g==",
       "requires": {
-        "babel-runtime": "^6.26.0",
+        "@babel/runtime": "7.0.0-beta.56",
         "change-emitter": "^0.1.2",
         "fbjs": "^0.8.1",
         "hoist-non-react-statics": "^2.3.1",
         "react-lifecycles-compat": "^3.0.2",
         "symbol-observable": "^1.0.4"
+      },
+      "dependencies": {
+        "@babel/runtime": {
+          "version": "7.0.0-beta.56",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.0.0-beta.56.tgz",
+          "integrity": "sha512-vP9XV2VP013UEyZdU9eWClCsm6rQPUYHVNCfmpcv5uKviW7mKmUZq71Y5cr5dYsFKfnGDxSo8h6plUGR60lwHg==",
+          "requires": {
+            "regenerator-runtime": "^0.12.0"
+          }
+        },
+        "regenerator-runtime": {
+          "version": "0.12.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz",
+          "integrity": "sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg=="
+        }
       }
     },
     "redent": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -47,9 +47,9 @@
     "@babel/runtime": "7.0.0-beta.54",
     "lodash.throttle": "^4.1.1",
     "react-addons-css-transition-group": "^15.6.2",
-    "react-event-listener": "^0.6.1",
+    "react-event-listener": "^0.6.2",
     "react-text-mask": "=5.4.1",
-    "recompose": "^0.27.1"
+    "recompose": "^0.28.0"
   },
   "size-limit": [
     {

--- a/lib/src/_shared/BasePicker.jsx
+++ b/lib/src/_shared/BasePicker.jsx
@@ -2,7 +2,7 @@ import compose from 'recompose/compose';
 import lifecycle from 'recompose/lifecycle';
 import setDisplayName from 'recompose/setDisplayName';
 import withHandlers from 'recompose/withHandlers';
-import withRenderProps from 'recompose/withRenderProps';
+import toRenderProps from 'recompose/toRenderProps';
 import withState from 'recompose/withState';
 
 import withUtils from '../_shared/WithUtils';
@@ -62,5 +62,5 @@ export const BasePickerHoc = compose(
   }),
 );
 
-export default withRenderProps(BasePickerHoc);
+export default toRenderProps(BasePickerHoc);
 


### PR DESCRIPTION
- [x] I have changed my target branch to **develop** :facepunch: 

### Closes # <!-- Please refer issue number here, if exists -->

## Description
Currently for people with @babel/runtime >=beta.56 the build breaks due to issues in recompose. Updating the deps fixes the issue.

It would be awesome if you could cut a new release with the fix included.