### PR TITLE
Update DateTextField typescript interface

### DIFF
--- a/lib/__tests__/_shared/DateTextField.test.js
+++ b/lib/__tests__/_shared/DateTextField.test.js
@@ -26,7 +26,7 @@ describe('DateTextField', () => {
 });
 
 
-describe('DateTextField keboard mode', () => {
+describe('DateTextField keyboard mode', () => {
   let component;
 
   beforeEach(() => {

--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -24,6 +24,10 @@ export interface DateTextFieldProps extends Omit<TextFieldProps, 'onChange' | 'v
     invalidDateMessage?: React.ReactNode;
     clearable?: boolean;
     TextFieldComponent?: React.ComponentType<TextFieldProps>;
+    InputAdornmentProps?: object;
+    adornmentPosition?: "start" | "end";
+    onError?: () => void;
+    onInputChange?: () => void;
 }
 
 declare const DateTextField: ComponentClass<DateTextFieldProps>;


### PR DESCRIPTION
This PR closes #570 

## Description
- Update the typescript interface for DateTextField to support InputAdornmentProps, adornmentPosition, onError and onInputChange. This commit will allow the use of those four properties in typescript projects.
- Minor spelling fix