### PR TITLE
Properly implement findClosestEnabledDate()

### DIFF
--- a/lib/__tests__/_helpers/date-utils.test.js
+++ b/lib/__tests__/_helpers/date-utils.test.js
@@ -2,11 +2,97 @@ import { utilsToUse } from '../test-utils';
 import { findClosestEnabledDate } from '../../src/_helpers/date-utils';
 
 describe('findClosestEnabledDate', () => {
-  it('Should return now if its enabled and passed disablePast | disableFuture', () => {
-    const today = utilsToUse.format(utilsToUse.date(), 'YYYY-MM-DD');
+  const day18thText = utilsToUse.getDayText(utilsToUse.date('2018-08-18'));
+  const only18th = date => utilsToUse.getDayText(date) !== day18thText;
+  it('Should return null if all dates are disabled', () => {
     const result = findClosestEnabledDate({
       date: utilsToUse.date('2000-01-01'),
-      minDate: '2100-01-01',
+      minDate: '1999-01-01', // Use close-by min/max dates to reduce the test runtime.
+      maxDate: '2001-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: () => true,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(result).toBe(null);
+  });
+  it('Should return given date if it is enabled', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2000-01-01'),
+      minDate: '1900-01-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: () => false,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2000-01-01'))).toBe(true);
+  });
+  it('Should return next 18th going from 10th', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2018-08-10'),
+      minDate: '1900-01-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2018-08-18'))).toBe(true);
+  });
+  it('Should return previous 18th going from 1st', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2018-08-01'),
+      minDate: '1900-01-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2018-07-18'))).toBe(true);
+  });
+  it('Should return future 18th if disablePast', () => {
+    const today = utilsToUse.startOfDay(utilsToUse.date());
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2000-01-01'),
+      minDate: '1900-01-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: true,
+    });
+
+    expect(utilsToUse.getDayText(result)).toBe(day18thText);
+    expect(utilsToUse.isBefore(result, today)).toBe(false);
+    expect(utilsToUse.isBefore(result, utilsToUse.addDays(today, 31))).toBe(true);
+  });
+  it('Should return past Saturday if disableFuture', () => {
+    const today = utilsToUse.startOfDay(utilsToUse.date());
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2099-01-01'),
+      minDate: '1900-01-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: true,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.getDayText(result)).toBe(day18thText);
+    expect(utilsToUse.isBefore(result, today)).toBe(true);
+    expect(utilsToUse.isBefore(result, utilsToUse.addDays(today, -31))).toBe(false);
+  });
+  it('Should return now if disablePast+disableFuture and now is valid', () => {
+    const today = utilsToUse.startOfDay(utilsToUse.date());
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2000-01-01'),
+      minDate: '1900-01-01',
       maxDate: '2100-01-01',
       utils: utilsToUse,
       shouldDisableDate: () => false,
@@ -14,35 +100,85 @@ describe('findClosestEnabledDate', () => {
       disablePast: true,
     });
 
-    expect(utilsToUse.format(result, 'YYYY-MM-DD')).toBe(today);
+    expect(utilsToUse.isSameDay(result, today)).toBe(true);
   });
-
-  it('Should return min date if its closest to now', () => {
-    const result = findClosestEnabledDate({
-      date: utilsToUse.date('2000-01-01'),
-      minDate: '2010-01-01',
-      maxDate: '2100-01-01',
-      utils: utilsToUse,
-      shouldDisableDate: () => false,
-      disableFuture: false,
-      disablePast: false,
-    });
-
-    expect(result).toEqual(utilsToUse.date('2010-01-01'));
-  });
-
-  it('Should return max date if its closest to now', () => {
+  it('Should return null if disablePast+disableFuture and now is invalid', () => {
+    const today = utilsToUse.date();
     const result = findClosestEnabledDate({
       date: utilsToUse.date('2000-01-01'),
       minDate: '1900-01-01',
-      maxDate: '2010-01-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: (date) => utilsToUse.isSameDay(date, today),
+      disableFuture: true,
+      disablePast: true,
+    });
+
+    expect(result).toBeNull();
+  });
+  it('Should return minDate if it is after the date and valid', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2000-01-01'),
+      minDate: '2018-08-18',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2018-08-18'))).toBe(true);
+  });
+  it('Should return next 18th after minDate', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2000-01-01'),
+      minDate: '2018-08-01',
+      maxDate: '2100-01-01',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2018-08-18'))).toBe(true);
+  });
+  it('Should return maxDate if it is before the date and valid', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2050-01-01'),
+      minDate: '1900-01-01',
+      maxDate: '2018-07-18',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2018-07-18'))).toBe(true);
+  });
+  it('Should return previous 18th before maxDate', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2050-01-01'),
+      minDate: '1900-01-01',
+      maxDate: '2018-08-17',
+      utils: utilsToUse,
+      shouldDisableDate: only18th,
+      disableFuture: false,
+      disablePast: false,
+    });
+
+    expect(utilsToUse.isSameDay(result, utilsToUse.date('2018-07-18'))).toBe(true);
+  });
+  it('Should return null if minDate is after maxDate', () => {
+    const result = findClosestEnabledDate({
+      date: utilsToUse.date('2000-01-01'),
+      minDate: '2000-01-01',
+      maxDate: '1999-01-01',
       utils: utilsToUse,
       shouldDisableDate: () => false,
       disableFuture: false,
       disablePast: false,
     });
 
-    expect(result).toEqual(utilsToUse.date('2010-01-01'));
+    expect(result).toBeNull();
   });
 });
-

--- a/lib/src/_helpers/date-utils.js
+++ b/lib/src/_helpers/date-utils.js
@@ -8,17 +8,34 @@ export const findClosestEnabledDate = ({
   disablePast,
   shouldDisableDate,
 }) => {
-  const now = utils.date();
-
-  if ((disableFuture || disablePast) && !shouldDisableDate(now)) {
-    return now;
+  const today = utils.startOfDay(utils.date());
+  minDate = minDate && utils.date(minDate);
+  maxDate = maxDate && utils.date(maxDate);
+  if (disablePast && utils.isBefore(minDate, today)) minDate = today;
+  if (disableFuture && utils.isAfter(maxDate, today)) maxDate = today;
+  let forward = utils.date(date);
+  let backward = utils.date(date);
+  if (utils.isBefore(date, minDate)) {
+    forward = minDate;
+    backward = null;
+  }
+  if (utils.isAfter(date, maxDate)) {
+    if (backward) backward = maxDate;
+    forward = null;
   }
 
-  const diffFromMaxDate = Math.abs(utils.getDiff(date, maxDate));
-  const diffFromMinDate = Math.abs(utils.getDiff(date, minDate));
-
-  return diffFromMaxDate < diffFromMinDate
-    ? utils.date(maxDate)
-    : utils.date(minDate);
+  while (forward || backward) {
+    if (forward && utils.isAfter(forward, maxDate)) forward = null;
+    if (backward && utils.isBefore(backward, minDate)) backward = null;
+    if (forward) {
+      if (!shouldDisableDate(forward)) return forward;
+      forward = utils.addDays(forward, 1);
+    }
+    if (backward) {
+      if (!shouldDisableDate(backward)) return backward;
+      backward = utils.addDays(backward, -1);
+    }
+  }
+  return null;
 };
 


### PR DESCRIPTION
Now it actually returns the closest enabled date.
Also add more test cases to the unit test and stop depending on the library-specific date format YYYY-MM-DD there.
