### PR TITLE
Call mergeDateAndTime() in YearSelection

### DIFF
--- a/lib/src/DatePicker/YearSelection.jsx
+++ b/lib/src/DatePicker/YearSelection.jsx
@@ -31,7 +31,7 @@ export class YearSelection extends PureComponent {
     const { date, onChange, utils } = this.props;
 
     const newDate = utils.setYear(date, year);
-    onChange(newDate);
+    onChange(utils.mergeDateAndTime(newDate, date));
   }
 
   getSelectedYearRef = (ref) => {


### PR DESCRIPTION
With the default implementations of `mergeDateAndTime()`, this does not make any difference. But when users customize how time-less dates are represented and override the function, this call is necessary to get a valid value.