### PR TITLE
Update typings. Add missing event type to onInputChange function signature

### DIFF
--- a/lib/src/_shared/DateTextField.d.ts
+++ b/lib/src/_shared/DateTextField.d.ts
@@ -27,7 +27,7 @@ export interface DateTextFieldProps extends Omit<TextFieldProps, 'onChange' | 'v
     InputAdornmentProps?: object;
     adornmentPosition?: "start" | "end";
     onError?: () => void;
-    onInputChange?: () => void;
+    onInputChange?: (e: React.FormEvent<HTMLInputElement>) => void;
 }
 
 declare const DateTextField: ComponentClass<DateTextFieldProps>;


### PR DESCRIPTION
DateTextFieldProps interface was missing event type in onInputChange function signature