### PR TITLE
Fix formatting of dates in docs examples

### DIFF
--- a/docs/src/Examples/Demo/DatePicker/CustomElementsDatePicker.jsx
+++ b/docs/src/Examples/Demo/DatePicker/CustomElementsDatePicker.jsx
@@ -37,7 +37,7 @@ class CustomElements extends PureComponent {
     }
 
     return date && isValid(date)
-      ? `Week of ${format(startOfWeek(date), 'MMM Do')}`
+      ? `Week of ${format(startOfWeek(date), 'MMM do')}`
       : invalidLabel;
   }
 
@@ -69,7 +69,7 @@ class CustomElements extends PureComponent {
     return (
       <div className={wrapperClassName}>
         <IconButton className={dayClassName}>
-          <span> { format(date, 'D')} </span>
+          <span> { format(date, 'd')} </span>
         </IconButton>
       </div>
     );

--- a/docs/src/Examples/Guides/ControllingProgrammatically.jsx
+++ b/docs/src/Examples/Guides/ControllingProgrammatically.jsx
@@ -33,7 +33,7 @@ class ControllingProgrammaticallyExample extends PureComponent {
             clearable
             ref={(node) => { this.picker = node; }}
             label="Open me from button"
-            format="D MMM YYYY"
+            format="d MMM YYYY"
             value={selectedDate}
             onChange={this.handleDateChange}
           />

--- a/docs/src/Examples/Guides/OverrideFormatPicker.jsx
+++ b/docs/src/Examples/Guides/OverrideFormatPicker.jsx
@@ -8,7 +8,7 @@ import format from 'date-fns/format';
 
 class LocalizedUtils extends DateFnsUtils {
   getDatePickerHeaderText(date) {
-    return format(date, 'D MMM YYYY', { locale: this.locale });
+    return format(date, 'd MMM YYYY', { locale: this.locale });
   }
 }
 
@@ -30,7 +30,7 @@ export default class DateFnsLocalizationExample extends PureComponent {
           <DatePicker
             clearable
             label="Localization done right"
-            format="D MMM YYYY"
+            format="d MMM YYYY"
             value={selectedDate}
             onChange={this.handleDateChange}
             clearLabel="vider"


### PR DESCRIPTION
The date-fns format function changed behaviour and required a corresponding change in some examples.