### PR TITLE
Make classnames a direct dependency

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "material-ui-pickers",
-  "version": "1.0.0-rc.13",
+  "version": "1.0.0-rc.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2726,8 +2726,7 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
-      "dev": true
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
     },
     "cli-boxes": {
       "version": "1.0.0",
@@ -5508,10 +5507,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.2.1.tgz",
       "integrity": "sha512-E2s1b4GVbt8PyG+iaRN6ks8N0Oy2LOJz7SIMUwWWWx7Mr5Z08hKkfpkKQbOtOGqzkFpckDJHjjZ8qfigN2W86A==",
-      "dev": true,
-      "requires": {
-        "icu4c-data": "^0.61.2"
-      }
+      "dev": true
     },
     "function-bind": {
       "version": "1.1.1",
@@ -6000,12 +5996,6 @@
           "dev": true
         }
       }
-    },
-    "icu4c-data": {
-      "version": "0.61.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.61.2.tgz",
-      "integrity": "sha512-OrIR8R6XtBhBVVp/4SILT2SGvxpqfBbvyrg7J6DrhcurRZDma4skSRHk/VQt4xwEtH/3edzYflbz7Q+HY3vs5g==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.1.12",

--- a/lib/package.json
+++ b/lib/package.json
@@ -32,7 +32,6 @@
     "email": "dmtr.kovalenko@outlook.com"
   },
   "peerDependencies": {
-    "classnames": "^2.2.5",
     "@material-ui/core": "^1.0.0-rc.0",
     "prop-types": "^15.6.0",
     "react": "^16.3.0",
@@ -45,6 +44,7 @@
   },
   "dependencies": {
     "@babel/runtime": "^7.0.0",
+    "classnames": "^2.2.5",
     "lodash.throttle": "^4.1.1",
     "react-event-listener": "^0.6.2",
     "react-text-mask": "=5.4.1",


### PR DESCRIPTION
I don't use classnames and it's not the best way to require installing
it from user. Peer depenencies should be used carefully. react,
material-ui are good packages for this purpose. Keeping classnames
in peer depenencies doesn't solve any problem. It's not so big package
to be a dependency bloat. And if one day there will be a different
version then I'm sure it will be a breaking change and users app will be
broken.