### PR TITLE
Replace lodash with throttle-debounce module

### DIFF
--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
+  "build/dist/material-ui-pickers.cjs.js": {
+    "bundled": 125336,
+    "minified": 71822,
+    "gzipped": 14810
+  },
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 122910,
-    "minified": 69609,
-    "gzipped": 14667,
+    "bundled": 122916,
+    "minified": 69611,
+    "gzipped": 14668,
     "treeshaked": {
       "rollup": {
-        "code": 59831,
-        "import_statements": 1528
+        "code": 59845,
+        "import_statements": 1542
       },
       "webpack": {
-        "code": 63773
+        "code": 63779
       }
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 821288,
-    "minified": 317481,
-    "gzipped": 77243
-  },
-  "build/dist/material-ui-pickers.cjs.js": {
-    "bundled": 125326,
-    "minified": 71812,
-    "gzipped": 14806
+    "bundled": 810890,
+    "minified": 315893,
+    "gzipped": 76519
   }
 }

--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -5507,7 +5507,18 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.2.1.tgz",
       "integrity": "sha512-E2s1b4GVbt8PyG+iaRN6ks8N0Oy2LOJz7SIMUwWWWx7Mr5Z08hKkfpkKQbOtOGqzkFpckDJHjjZ8qfigN2W86A==",
-      "dev": true
+      "dev": true,
+      "requires": {
+        "icu4c-data": "^0.60.2"
+      },
+      "dependencies": {
+        "icu4c-data": {
+          "version": "0.60.2",
+          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.60.2.tgz",
+          "integrity": "sha512-4ScORTYJPIDJRPtAkQWXfKqGk8u1ThOxFWCJ3jkq+rj/MU4cK6isCvhFiEjunivw1/bJ10LqNAaJ9pAK68DEZg==",
+          "dev": true
+        }
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -8399,11 +8410,6 @@
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
       "integrity": "sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=",
       "dev": true
-    },
-    "lodash.throttle": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/lodash.throttle/-/lodash.throttle-4.1.1.tgz",
-      "integrity": "sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ="
     },
     "lodash.uniq": {
       "version": "4.5.0",
@@ -12434,6 +12440,11 @@
       "resolved": "https://registry.npmjs.org/throat/-/throat-4.1.0.tgz",
       "integrity": "sha1-iQN8vJLFarGJJua6TLsgDhVnKmo=",
       "dev": true
+    },
+    "throttle-debounce": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/throttle-debounce/-/throttle-debounce-2.0.1.tgz",
+      "integrity": "sha512-Sr6jZBlWShsAaSXKyNXyNicOrJW/KtkDqIEwHt4wYwWA2wa/q67Luhqoujg48V8hTk60wB56tYrJJn6jc2R7VA=="
     },
     "through": {
       "version": "2.3.8",

--- a/lib/package.json
+++ b/lib/package.json
@@ -45,11 +45,11 @@
   "dependencies": {
     "@babel/runtime": "^7.0.0",
     "classnames": "^2.2.5",
-    "lodash.throttle": "^4.1.1",
     "react-event-listener": "^0.6.2",
     "react-text-mask": "=5.4.1",
     "react-transition-group": "^2.4.0",
-    "recompose": "^0.28.0"
+    "recompose": "^0.28.0",
+    "throttle-debounce": "^2.0.1"
   },
   "size-limit": [
     {

--- a/lib/src/DatePicker/components/Calendar.jsx
+++ b/lib/src/DatePicker/components/Calendar.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import keycode from 'keycode';
 import withStyles from '@material-ui/core/styles/withStyles';
 import EventListener from 'react-event-listener';
-import throttle from 'lodash.throttle';
+import { throttle } from 'throttle-debounce';
 
 import { findClosestEnabledDate } from '../../_helpers/date-utils';
 import CalendarHeader from './CalendarHeader';
@@ -87,7 +87,7 @@ export class Calendar extends Component {
     this.setState({ currentMonth: newMonth, slideDirection });
   };
 
-  throttledHandleChangeMonth = throttle(this.handleChangeMonth, 350)
+  throttledHandleChangeMonth = throttle(350, this.handleChangeMonth)
 
   validateMinMaxDate = (day) => {
     const { minDate, maxDate, utils } = this.props;


### PR DESCRIPTION
lodash.* packages was deprecated and will be removed in the next major
release of lodash.

This module has esm and cjs output which perfectly fits to our
distribution. As you can see this saves 1.5kb in umd and user bundles.