### PR TITLE
Fix umd bundle

### DIFF
--- a/lib/.babelrc
+++ b/lib/.babelrc
@@ -1,6 +1,6 @@
 {
   "presets": [
-    ["@babel/env", { "modules": false, "loose": true }],
+    ["@babel/env", { "loose": true }],
     "@babel/react"
   ],
   "plugins": [
@@ -9,14 +9,12 @@
   "env": {
     "test": {
       "plugins": [
-        "@babel/transform-runtime",
-        "@babel/transform-modules-commonjs"
+        "@babel/transform-runtime"
       ]
     },
     "cjs": {
       "plugins": [
-        "@babel/transform-runtime",
-        "@babel/transform-modules-commonjs"
+        "@babel/transform-runtime"
       ]
     }
   }

--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -19,8 +19,13 @@
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 810890,
-    "minified": 315893,
-    "gzipped": 76519
+    "bundled": 803439,
+    "minified": 311000,
+    "gzipped": 75854
+  },
+  "build/dist/material-ui-pickers.umd.min.js": {
+    "bundled": 718858,
+    "minified": 284929,
+    "gzipped": 69874
   }
 }

--- a/lib/package.json
+++ b/lib/package.json
@@ -77,8 +77,6 @@
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/plugin-proposal-class-properties": "^7.0.0",
-    "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
-    "@babel/plugin-transform-modules-commonjs": "^7.0.0",
     "@babel/plugin-transform-runtime": "^7.0.0",
     "@babel/preset-env": "^7.0.0",
     "@babel/preset-react": "^7.0.0",

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -2,12 +2,13 @@ import path from 'path';
 import babel from 'rollup-plugin-babel';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
+import replace from 'rollup-plugin-replace';
 import { uglify } from 'rollup-plugin-uglify';
 import { sizeSnapshot } from 'rollup-plugin-size-snapshot';
 import pkg from './package.json';
 
-// treat as externals not relative, not absolute and not reserved rollup paths
-const external = id => !id.startsWith('\0') && !id.startsWith('.') && !id.startsWith('/');
+// treat as externals not relative and not absolute paths
+const external = id => !id.startsWith('.') && !id.startsWith('/');
 
 const input = './src/index.js';
 const globals = {
@@ -77,6 +78,7 @@ export default [
       resolve({ extensions: ['.js', '.jsx'] }),
       babel(getBabelOptions({ useESModules: true })),
       commonjs(commonjsOptions),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('development') }),
       sizeSnapshot(),
     ],
   },
@@ -94,6 +96,8 @@ export default [
       resolve({ extensions: ['.js', '.jsx'] }),
       babel(getBabelOptions({ useESModules: true })),
       commonjs(commonjsOptions),
+      replace({ 'process.env.NODE_ENV': JSON.stringify('production') }),
+      sizeSnapshot(),
       uglify(),
     ],
   },


### PR DESCRIPTION
Seems like react transition group has NODE_ENV conditions. And since we
bundle this package in our umd we should replace all NODE_ENV for both
umd and min bundles.

Seems like material-ui-pickers is actually smaller than we thought.

Removed babel object rest spread plugin which is part of env preset.

Removed babel commonjs plugin because rollup-plugin-babel sets `modules`
option by itself. This a bit simplifies config.