### PR TITLE
Fixed Day formatting for inline picker example.

### DIFF
--- a/docs/src/Examples/Demo/DatePicker/InlineDatePicker.jsx
+++ b/docs/src/Examples/Demo/DatePicker/InlineDatePicker.jsx
@@ -39,7 +39,7 @@ export default class InlineDatePickerDemo extends PureComponent {
             label="With keyboard"
             value={selectedDate}
             onChange={this.handleDateChange}
-            format="DD/MM/YYYY"
+            format="dd/MM/YYYY"
             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
           />
         </div>


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes # <!-- Please refer issue number here, if exists -->

## Description
This fixes an issue I found in the `InlineDatePicker` example where the Date was incorrectly formatted to 'DD' instead of 'dd' for the day component. This can cause some odd looking output:

See: ![image](https://user-images.githubusercontent.com/801539/45607092-00b7ca00-ba8d-11e8-8174-bfb37c67d879.png)

Change the formatting to lower-case d resolves the problem by using the numeric date component, rather than the Day-name component.