### PR TITLE
Fixes to examples to resolve issue with Year decrementing

### DIFF
--- a/docs/src/Examples/Demo/DatePicker/InlineDatePicker.jsx
+++ b/docs/src/Examples/Demo/DatePicker/InlineDatePicker.jsx
@@ -1,5 +1,5 @@
-import React, { Fragment, PureComponent } from 'react';
 import { InlineDatePicker } from 'material-ui-pickers/DatePicker';
+import React, { Fragment, PureComponent } from 'react';
 
 export default class InlineDatePickerDemo extends PureComponent {
   state = {
@@ -39,7 +39,7 @@ export default class InlineDatePickerDemo extends PureComponent {
             label="With keyboard"
             value={selectedDate}
             onChange={this.handleDateChange}
-            format="dd/MM/YYYY"
+            format="dd/MM/yyyy"
             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
           />
         </div>

--- a/docs/src/Examples/Demo/DateTimePicker/InlineDateTimePicker.jsx
+++ b/docs/src/Examples/Demo/DateTimePicker/InlineDateTimePicker.jsx
@@ -1,5 +1,5 @@
-import React, { Fragment, PureComponent } from 'react';
 import { InlineDateTimePicker } from 'material-ui-pickers/DateTimePicker';
+import React, { Fragment, PureComponent } from 'react';
 
 export default class InlineDateTimePickerDemo extends PureComponent {
   state = {
@@ -29,7 +29,7 @@ export default class InlineDateTimePickerDemo extends PureComponent {
             label="With keyboard"
             value={selectedDate}
             onChange={this.handleDateChange}
-            format="DD/MM/YYYY"
+            format="DD/MM/yyyy"
             mask={[/\d/, /\d/, '/', /\d/, /\d/, '/', /\d/, /\d/, /\d/, /\d/]}
           />
         </div>

--- a/docs/src/Examples/Guides/ControllingProgrammatically.jsx
+++ b/docs/src/Examples/Guides/ControllingProgrammatically.jsx
@@ -1,9 +1,8 @@
-import React, { PureComponent } from 'react';
-import PropTypes from 'prop-types';
-import DatePicker from 'material-ui-pickers/DatePicker';
-
 import Button from '@material-ui/core/Button';
 import withStyles from '@material-ui/core/styles/withStyles';
+import DatePicker from 'material-ui-pickers/DatePicker';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
 
 class ControllingProgrammaticallyExample extends PureComponent {
   static propTypes = {
@@ -33,7 +32,7 @@ class ControllingProgrammaticallyExample extends PureComponent {
             clearable
             ref={(node) => { this.picker = node; }}
             label="Open me from button"
-            format="d MMM YYYY"
+            format="d MMM yyyy"
             value={selectedDate}
             onChange={this.handleDateChange}
           />

--- a/docs/src/Examples/Guides/OverrideFormatPicker.jsx
+++ b/docs/src/Examples/Guides/OverrideFormatPicker.jsx
@@ -1,10 +1,9 @@
-import React, { PureComponent } from 'react';
+import format from 'date-fns/format';
+import frLocale from 'date-fns/locale/fr';
 import DatePicker from 'material-ui-pickers/DatePicker';
 import DateFnsUtils from 'material-ui-pickers/utils/date-fns-utils';
 import MuiPickersUtilsProvider from 'material-ui-pickers/utils/MuiPickersUtilsProvider';
-
-import frLocale from 'date-fns/locale/fr';
-import format from 'date-fns/format';
+import React, { PureComponent } from 'react';
 
 class LocalizedUtils extends DateFnsUtils {
   getDatePickerHeaderText(date) {
@@ -30,7 +29,7 @@ export default class DateFnsLocalizationExample extends PureComponent {
           <DatePicker
             clearable
             label="Localization done right"
-            format="d MMM YYYY"
+            format="d MMM yyyy"
             value={selectedDate}
             onChange={this.handleDateChange}
             clearLabel="vider"


### PR DESCRIPTION
Resolves problem outlined in https://github.com/dmtrKovalenko/material-ui-pickers/issues/613

This PR closes #613

## Description
The samples for DatePicker with custom format use `YYYY` to specify the year component of the date being displayed. This caused an issue (still not sure why) where performing the following steps:

1. Selecting a Date
2. Clicking outside the DatePicker (Blur)
3. Clicking inside the DatePicker (Focus)
4. Clicking back outside the DatePicker (Blur)

would cause the year to be decremented back to the previous year.

This is a result of using `Y` instead of `y` in the date form.

This fix update the documentation to use the correct `y` component. 

I'm currently unsure whether the underlying issue requires addressing.