### PR TITLE
Remove unnecessary import from definitions

### DIFF
--- a/lib/src/index.d.ts
+++ b/lib/src/index.d.ts
@@ -1,5 +1,3 @@
-import { getHeapStatistics } from 'v8';
-
 export { default as DatePicker, DatePickerProps } from './DatePicker';
 
 export { default as TimePicker, TimePickerProps } from './TimePicker';


### PR DESCRIPTION
The import from v8 in the definitions is plain unnecessary and seems to break my build with this error too:
```
Error:(1, 35) TS2307: Cannot find module 'v8'.
```
