### PR TITLE
Double extension of interfaces is not allowed in TS

### DIFF
--- a/lib/src/_shared/DateTextField.tsx
+++ b/lib/src/_shared/DateTextField.tsx
@@ -75,9 +75,8 @@ const getError = (
   return '';
 };
 
-export interface DateTextFieldProps
-  extends WithUtilsProps,
-    Omit<TextFieldProps, 'onError' | 'onChange' | 'value'> {
+export type DateTextFieldProps = WithUtilsProps & Omit<TextFieldProps, 'onError' | 'onChange' | 'value'> &
+     {
   value: DateType;
   minDate?: DateType;
   minDateMessage?: React.ReactNode;


### PR DESCRIPTION
## Description

There is an error in TS: 'An interface may only extend a class or another interface' in DateTextField, because double interface extensions are not allowed in TS (https://github.com/Microsoft/TypeScript/issues/16936) Changed interface to type in this PR.