### PR TITLE
Fix initialFocusedDate update on prop change

### DIFF
--- a/lib/src/__tests__/_shared/BasePicker.test.tsx
+++ b/lib/src/__tests__/_shared/BasePicker.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render } from 'react-dom';
 import { BasePicker } from '../../_shared/BasePicker';
-import { utilsToUse } from '../test-utils';
+import { shallow, utilsToUse } from '../test-utils';
 
 const renderComponent = (Component: React.ComponentType<any>) => {
   const div = (global as any).document.createElement('div');
@@ -67,6 +67,26 @@ describe('BasePicker', () => {
       expect(utilsToUse.isEqual(renderCallParam.date, initialFocusedDate)).toBe(
         true
       );
+    });
+
+    it('passes updated initialFocusedDate as date if value is not provided and initialFocusedDate has changed', () => {
+      const initialFocusedDate = utilsToUse.date('2018-01-01');
+      const newInitialFocusedDate = utilsToUse.date('2018-02-01');
+      const renderFuncMock = getRenderFuncMock();
+
+      const component = shallow(
+        <BasePicker
+          initialFocusedDate={initialFocusedDate}
+          utils={utilsToUse}
+          onChange={jest.fn()}
+          value={null}
+        >
+          {renderFuncMock}
+        </BasePicker>
+      );
+
+      component.setProps({ initialFocusedDate: newInitialFocusedDate });
+      expect(component.state('date')).toEqual(newInitialFocusedDate);
     });
 
     it('passes utils.date() as date if value and initialFocusedDate are not provided', () => {

--- a/lib/src/_shared/BasePicker.tsx
+++ b/lib/src/_shared/BasePicker.tsx
@@ -58,8 +58,12 @@ export class BasePicker extends React.Component<
   };
 
   public componentDidUpdate(prevProps: OuterBasePickerProps) {
-    const { utils, value } = this.props;
-    if (prevProps.value !== value || prevProps.utils.locale !== utils.locale) {
+    const { utils, value, initialFocusedDate } = this.props;
+    if (
+      prevProps.value !== value ||
+      prevProps.utils.locale !== utils.locale ||
+      prevProps.initialFocusedDate !== initialFocusedDate
+    ) {
       this.changeDate(getInitialDate(this.props));
     }
   }


### PR DESCRIPTION
Fix initialFocusedDate update on prop change

If calendar initial date depends on `initialFocusedDate` prop, when we update that prop the initial date will not change. This PR fix that bug