### PR TITLE
Change how moment is imported

### DIFF
--- a/lib/src/utils/moment-utils/index.ts
+++ b/lib/src/utils/moment-utils/index.ts
@@ -1,4 +1,4 @@
-import defaultMoment from 'moment';
+import * as defaultMoment from 'moment';
 import { Utils } from '../../typings/utils';
 
 interface Opts {


### PR DESCRIPTION
## Description

Fixes TS1192: Module moment as no default export while using Typescript.