### PR TITLE
Allow overriding the picker component in the inline/model wrappers

### DIFF
--- a/lib/src/DatePicker/DatePickerInline.tsx
+++ b/lib/src/DatePicker/DatePickerInline.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 import { Omit } from '@material-ui/core';
 import BasePicker, { BasePickerProps } from '../_shared/BasePicker';
-import DomainPropTypes from '../constants/prop-types';
+import DomainPropTypes, {ComponentType} from '../constants/prop-types';
 import InlineWrapper, { InlineWrapperProps } from '../wrappers/InlineWrapper';
 import Calendar from './components/Calendar';
 import DatePicker, { BaseDatePickerProps } from './DatePicker';
@@ -21,6 +21,7 @@ export interface DatePickerInlineProps
       | 'onlyCalendar'
     > {
   onlyCalendar?: boolean;
+  OnlyCalendarComponent?: ComponentType,
 }
 
 export const DatePickerInline: React.SFC<DatePickerInlineProps> = props => {
@@ -44,11 +45,12 @@ export const DatePickerInline: React.SFC<DatePickerInlineProps> = props => {
     value,
     autoOk,
     onlyCalendar,
+    PickerComponent,
+    OnlyCalendarComponent,
     ...other
   } = props;
 
-  const ComponentToShow = onlyCalendar ? Calendar : DatePicker;
-
+  const ComponentToShow = onlyCalendar ? OnlyCalendarComponent! : PickerComponent!;
   return (
     <BasePicker {...props} autoOk>
       {({
@@ -114,6 +116,8 @@ export const DatePickerInline: React.SFC<DatePickerInlineProps> = props => {
   allowKeyboardControl: PropTypes.bool,
   forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
   autoOk: PropTypes.bool,
+  PickerComponent: DomainPropTypes.component,
+  OnlyCalendarComponent: DomainPropTypes.component,
 };
 
 DatePickerInline.defaultProps = {
@@ -135,6 +139,8 @@ DatePickerInline.defaultProps = {
   forwardedRef: undefined,
   autoOk: undefined,
   onlyCalendar: false,
+  PickerComponent: DatePicker,
+  OnlyCalendarComponent: Calendar,
 };
 
 export default React.forwardRef((props: DatePickerInlineProps, ref) => (

--- a/lib/src/DatePicker/DatePickerModal.tsx
+++ b/lib/src/DatePicker/DatePickerModal.tsx
@@ -32,9 +32,11 @@ export const DatePickerModal: React.SFC<DatePickerModalProps> = props => {
     rightArrowIcon,
     shouldDisableDate,
     value,
+    PickerComponent,
     ...other
   } = props;
 
+  const ThePickerComponent = PickerComponent!;
   return (
     <BasePicker {...props}>
       {({
@@ -65,7 +67,7 @@ export const DatePickerModal: React.SFC<DatePickerModalProps> = props => {
           isAccepted={isAccepted}
           {...other}
         >
-          <DatePicker
+          <ThePickerComponent
             date={date}
             allowKeyboardControl={allowKeyboardControl}
             animateYearScrolling={animateYearScrolling}
@@ -128,6 +130,7 @@ export const DatePickerModal: React.SFC<DatePickerModalProps> = props => {
   /** Enables keyboard listener for moving between days in calendar */
   allowKeyboardControl: PropTypes.bool,
   forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  PickerComponent: DomainPropTypes.component,
 };
 
 DatePickerModal.defaultProps = {
@@ -148,6 +151,7 @@ DatePickerModal.defaultProps = {
   labelFunc: undefined,
   shouldDisableDate: undefined,
   forwardedRef: undefined,
+  PickerComponent: DatePicker,
 };
 
 export default React.forwardRef((props: DatePickerModalProps, ref) => (

--- a/lib/src/DateTimePicker/DateTimePicker.tsx
+++ b/lib/src/DateTimePicker/DateTimePicker.tsx
@@ -18,7 +18,7 @@ import { withUtils, WithUtilsProps } from '../_shared/WithUtils';
 import DateTimePickerView, {
   DateTimePickerViewType,
 } from '../constants/DateTimePickerView';
-import DomainPropTypes from '../constants/prop-types';
+import DomainPropTypes, {ComponentType} from '../constants/prop-types';
 import { BaseDatePickerProps } from '../DatePicker/DatePicker';
 import { MaterialUiPickersDate } from '../typings/date';
 
@@ -30,7 +30,7 @@ export interface BaseDateTimePickerProps
   openTo?: DateTimePickerViewType;
   dateRangeIcon?: React.ReactNode;
   timeIcon?: React.ReactNode;
-  ViewContainerComponent?: string | React.ComponentType<any>;
+  ViewContainerComponent?: ComponentType;
 }
 
 export interface DateTimePickerProps
@@ -79,11 +79,7 @@ export class DateTimePicker extends React.Component<
     showTabs: PropTypes.bool,
     timeIcon: PropTypes.node,
     utils: PropTypes.object.isRequired,
-    ViewContainerComponent: PropTypes.oneOfType([
-      PropTypes.string,
-      PropTypes.func,
-      PropTypes.object,
-    ]),
+    ViewContainerComponent: DomainPropTypes.component,
   };
 
   public static defaultProps = {

--- a/lib/src/DateTimePicker/DateTimePickerInline.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerInline.tsx
@@ -37,9 +37,11 @@ export const DateTimePickerInline: React.SFC<
     animateYearScrolling,
     forwardedRef,
     allowKeyboardControl,
+    PickerComponent,
     ...other
   } = props;
 
+  const ThePickerComponent = PickerComponent!;
   return (
     <BasePicker {...props} autoOk>
       {({
@@ -67,7 +69,7 @@ export const DateTimePickerInline: React.SFC<
           )}
           {...other}
         >
-          <DateTimePicker
+          <ThePickerComponent
             allowKeyboardControl={allowKeyboardControl}
             ampm={ampm}
             animateYearScrolling={animateYearScrolling}
@@ -116,6 +118,7 @@ export const DateTimePickerInline: React.SFC<
   openTo: PropTypes.oneOf(['year', 'date', 'hour', 'minutes']),
   allowKeyboardControl: PropTypes.bool,
   forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  PickerComponent: DomainPropTypes.component,
 };
 
 (DateTimePickerInline as any).defaultProps = {
@@ -140,6 +143,7 @@ export const DateTimePickerInline: React.SFC<
   animateYearScrolling: false,
   forwardedRef: undefined,
   allowKeyboardControl: true,
+  PickerComponent: DateTimePicker,
 };
 
 export default React.forwardRef((props: DateTimePickerInlineProps, ref) => (

--- a/lib/src/DateTimePicker/DateTimePickerModal.tsx
+++ b/lib/src/DateTimePicker/DateTimePickerModal.tsx
@@ -38,9 +38,11 @@ export const DateTimePickerModal: React.SFC<
     animateYearScrolling,
     forwardedRef,
     allowKeyboardControl,
+    PickerComponent,
     ...other
   } = props;
 
+  const ThePickerComponent = PickerComponent!;
   return (
     <BasePicker {...props}>
       {({
@@ -74,7 +76,7 @@ export const DateTimePickerModal: React.SFC<
           )}
           {...other}
         >
-          <DateTimePicker
+          <ThePickerComponent
             allowKeyboardControl={allowKeyboardControl}
             ampm={ampm}
             animateYearScrolling={animateYearScrolling}
@@ -147,6 +149,7 @@ export const DateTimePickerModal: React.SFC<
   /** Enables keyboard listener for moving between days in calendar */
   allowKeyboardControl: PropTypes.bool,
   forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  PickerComponent: DomainPropTypes.component,
 };
 
 (DateTimePickerModal as any).defaultProps = {
@@ -171,6 +174,7 @@ export const DateTimePickerModal: React.SFC<
   animateYearScrolling: false,
   forwardedRef: undefined,
   allowKeyboardControl: true,
+  PickerComponent: DateTimePicker,
 };
 
 export default React.forwardRef((props: DateTimePickerModalProps, ref) => (

--- a/lib/src/TimePicker/TimePickerInline.tsx
+++ b/lib/src/TimePicker/TimePickerInline.tsx
@@ -20,9 +20,11 @@ export const TimePickerInline: React.SFC<TimePickerInlineProps> = props => {
     ampm,
     forwardedRef,
     seconds,
+    PickerComponent,
     ...other
   } = props;
 
+  const ThePickerComponent = PickerComponent!;
   return (
     <BasePicker {...props} autoOk>
       {({
@@ -43,7 +45,7 @@ export const TimePickerInline: React.SFC<TimePickerInlineProps> = props => {
           format={pick12hOr24hFormat(utils.time12hFormat, utils.time24hFormat)}
           {...other}
         >
-          <TimePicker
+          <ThePickerComponent
             date={date}
             onChange={handleChange}
             ampm={ampm}
@@ -62,6 +64,7 @@ export const TimePickerInline: React.SFC<TimePickerInlineProps> = props => {
   ampm: PropTypes.bool,
   seconds: PropTypes.bool,
   forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  PickerComponent: DomainPropTypes.component,
 };
 
 TimePickerInline.defaultProps = {
@@ -70,6 +73,7 @@ TimePickerInline.defaultProps = {
   format: undefined,
   forwardedRef: undefined,
   seconds: false,
+  PickerComponent: TimePicker,
 };
 
 export default React.forwardRef((props: TimePickerInlineProps, ref) => (

--- a/lib/src/TimePicker/TimePickerModal.tsx
+++ b/lib/src/TimePicker/TimePickerModal.tsx
@@ -21,9 +21,11 @@ export const TimePickerModal: React.SFC<TimePickerModalProps> = props => {
     ampm,
     forwardedRef,
     seconds,
+    PickerComponent,
     ...other
   } = props;
 
+  const ThePickerComponent = PickerComponent!;
   return (
     <BasePicker {...props}>
       {({
@@ -50,7 +52,7 @@ export const TimePickerModal: React.SFC<TimePickerModalProps> = props => {
           format={pick12hOr24hFormat(utils.time12hFormat, utils.time24hFormat)}
           {...other}
         >
-          <TimePicker
+          <ThePickerComponent
             date={date}
             onChange={handleChange}
             ampm={ampm}
@@ -76,6 +78,7 @@ export const TimePickerModal: React.SFC<TimePickerModalProps> = props => {
   /** Show the seconds view */
   seconds: PropTypes.bool,
   forwardedRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  PickerComponent: DomainPropTypes.component,
 };
 
 TimePickerModal.defaultProps = {
@@ -85,6 +88,7 @@ TimePickerModal.defaultProps = {
   ampm: true,
   forwardedRef: undefined,
   seconds: false,
+  PickerComponent: TimePicker,
 };
 
 export default React.forwardRef((props: TimePickerModalProps, ref) => (

--- a/lib/src/constants/prop-types.ts
+++ b/lib/src/constants/prop-types.ts
@@ -1,4 +1,13 @@
 import * as PropTypes from 'prop-types';
+import * as React from 'react';
+
+const component = PropTypes.oneOfType([
+  PropTypes.func,
+  PropTypes.object,
+  PropTypes.string,
+]);
+
+export type ComponentType = string | React.ComponentType<any>;
 
 const date = PropTypes.oneOfType([
   PropTypes.object,
@@ -9,4 +18,4 @@ const date = PropTypes.oneOfType([
 
 export type DateType = object | string | number | Date | null | undefined;
 
-export default { date };
+export default { component, date };

--- a/lib/src/wrappers/InlineWrapper.tsx
+++ b/lib/src/wrappers/InlineWrapper.tsx
@@ -7,7 +7,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import EventListener from 'react-event-listener';
 import DateTextField, { DateTextFieldProps } from '../_shared/DateTextField';
-import DomainPropTypes from '../constants/prop-types';
+import DomainPropTypes, {ComponentType} from '../constants/prop-types';
 
 export interface InlineWrapperProps extends Partial<DateTextFieldProps> {
   onOpen?: () => void;
@@ -16,6 +16,7 @@ export interface InlineWrapperProps extends Partial<DateTextFieldProps> {
   PopoverProps?: Partial<PopoverPropsType>;
   isAccepted: boolean;
   onlyCalendar: boolean;
+  PickerComponent?: ComponentType;
 }
 
 export class InlineWrapper extends React.PureComponent<

--- a/lib/src/wrappers/ModalWrapper.tsx
+++ b/lib/src/wrappers/ModalWrapper.tsx
@@ -5,7 +5,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import DateTextField, { DateTextFieldProps } from '../_shared/DateTextField';
 import ModalDialog from '../_shared/ModalDialog';
-import DomainPropTypes from '../constants/prop-types';
+import DomainPropTypes, {ComponentType} from '../constants/prop-types';
 
 export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
   onAccept?: () => void;
@@ -23,6 +23,7 @@ export interface ModalWrapperProps extends Partial<DateTextFieldProps> {
   container?: React.ReactNode;
   DialogProps?: Partial<Omit<DialogPropsType, 'classes'>>;
   isAccepted?: boolean;
+  PickerComponent?: ComponentType;
 }
 
 export default class ModalWrapper extends React.PureComponent<


### PR DESCRIPTION
This allows users to use a customized DateTimePicker inside the wrappers. In the simplest case, users can just supply a function that does only minor modifications to the props of the picker and then instantiates the original DateTimePicker from the library.