### PR TITLE
Upgrade date-fns to alpha 21

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -2505,9 +2505,9 @@
       }
     },
     "date-fns": {
-      "version": "2.0.0-alpha.16",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.16.tgz",
-      "integrity": "sha1-0kmmybeZJSZS+54/JUYOr53oasc=",
+      "version": "2.0.0-alpha.21",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.0.0-alpha.21.tgz",
+      "integrity": "sha512-QL6ZzDhQVAGzYElbGcMCCwDhobclw5jIJG9oD9n0kA8+PLNqtP/V76vkzUXvOiXm421aAXjLFgo3o3cq33cdew==",
       "dev": true
     },
     "date-now": {

--- a/lib/package.json
+++ b/lib/package.json
@@ -39,7 +39,7 @@
   },
   "optionalDependenciesgca": {
     "moment": "^2.19.2",
-    "date-fns": "2.0.0-alpha.16",
+    "date-fns": "2.0.0-alpha.21",
     "luxon": "^1.0.0"
   },
   "dependencies": {
@@ -95,7 +95,7 @@
     "classnames": "^2.2.6",
     "codecov": "^3.1.0",
     "cross-env": "^5.2.0",
-    "date-fns": "2.0.0-alpha.16",
+    "date-fns": "2.0.0-alpha.21",
     "enzyme": "^3.7.0",
     "enzyme-adapter-react-16": "^1.6.0",
     "fs-extra": "^7.0.0",


### PR DESCRIPTION
I don't see breaking changes before this version. But they at least fixed esm for path imports.
https://gist.github.com/kossnocorp/a307a464760b405bb78ef5020a4ab136#v200-alpha21