### PR TITLE
Pass keepCharPositions prop to DateInputField

### DIFF
--- a/lib/src/_shared/DateTextField.tsx
+++ b/lib/src/_shared/DateTextField.tsx
@@ -102,6 +102,7 @@ export interface DateTextFieldProps
   /** Input mask, used in keyboard mode read more <a href="https://github.com/text-mask/text-mask/blob/master/componentDocumentation.md#readme">here</a> */
   mask?: any;
   pipe?: any;
+  keepCharPositions?: boolean;
   onChange: (date: MaterialUiPickersDate) => void;
   onClear?: () => void;
   /** On/off manual keyboard input mode */
@@ -174,6 +175,7 @@ export class DateTextField extends React.PureComponent<DateTextFieldProps> {
     onError: PropTypes.func,
     onInputChange: PropTypes.func,
     pipe: PropTypes.func,
+    keepCharPositions: PropTypes.bool,
   };
 
   public static defaultProps = {
@@ -204,6 +206,7 @@ export class DateTextField extends React.PureComponent<DateTextFieldProps> {
     InputAdornmentProps: {},
     adornmentPosition: 'end',
     pipe: undefined,
+    keepCharPositions: false,
   };
   public static updateState = (props: DateTextFieldProps) => ({
     value: props.value,
@@ -342,6 +345,7 @@ export class DateTextField extends React.PureComponent<DateTextFieldProps> {
       onClear,
       onClick,
       pipe,
+      keepCharPositions,
       TextFieldComponent,
       utils,
       value,
@@ -355,6 +359,7 @@ export class DateTextField extends React.PureComponent<DateTextFieldProps> {
       inputProps: {
         mask: !keyboard ? null : mask,
         pipe: !keyboard ? null : pipe,
+        keepCharPositions: !keyboard ? null : keepCharPositions,
         readOnly: !keyboard,
       },
     };


### PR DESCRIPTION
In order to use pipe (to modify the user input in keyboard mode). I want/need to be able to set keepCharPositions.

## Description

I noticed https://github.com/dmtrKovalenko/material-ui-pickers/issues/616 and the associated PR. So there is an expectation that pipe should work.

In the docs for the TextMask addon https://github.com/text-mask/text-mask/tree/master/addons it says "For createAutoCorrectedDatePipe to work properly, the Text Mask component needs to be configured with keepCharPositions set to true." (it gets the value of that prop in its config argument). So it seems like a pretty good idea to pass this on through.

This change passes that prop through to the input when in keyboard mode in the same way that mask and pipe are currently passed.
