### PR TITLE
replace withTheme HOC with withTheme option.

### DIFF
--- a/lib/.size-snapshot.json
+++ b/lib/.size-snapshot.json
@@ -1,26 +1,26 @@
 {
   "build/dist/material-ui-pickers.esm.js": {
-    "bundled": 106346,
-    "minified": 61842,
-    "gzipped": 14583,
+    "bundled": 107577,
+    "minified": 62419,
+    "gzipped": 14689,
     "treeshaked": {
       "rollup": {
-        "code": 48487,
-        "import_statements": 1312
+        "code": 48996,
+        "import_statements": 1262
       },
       "webpack": {
-        "code": 55403
+        "code": 55864
       }
     }
   },
   "build/dist/material-ui-pickers.umd.js": {
-    "bundled": 153287,
-    "minified": 76055,
-    "gzipped": 20143
+    "bundled": 215797,
+    "minified": 94245,
+    "gzipped": 24747
   },
   "build/dist/material-ui-pickers.umd.min.js": {
-    "bundled": 143700,
-    "minified": 71268,
-    "gzipped": 19112
+    "bundled": 195212,
+    "minified": 88013,
+    "gzipped": 23427
   }
 }

--- a/lib/src/DateTimePicker/components/DateTimePickerTabs.tsx
+++ b/lib/src/DateTimePicker/components/DateTimePickerTabs.tsx
@@ -4,7 +4,6 @@ import * as React from 'react';
 import { Theme } from '@material-ui/core';
 import Paper from '@material-ui/core/Paper';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
-import withTheme from '@material-ui/core/styles/withTheme';
 import Tab from '@material-ui/core/Tab';
 import Tabs from '@material-ui/core/Tabs';
 import { DateRangeIcon } from '../../_shared/icons/DateRangeIcon';
@@ -81,4 +80,4 @@ export const styles = (theme: Theme) => ({
   },
 });
 
-export default withTheme()(withStyles(styles, { name: 'MuiPickerDTTabs' })(DateTimePickerTabs));
+export default withStyles(styles, { name: 'MuiPickerDTTabs', withTheme: true })(DateTimePickerTabs);


### PR DESCRIPTION

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #876  <!-- Please refer issue number here, if exists -->

## Description
This pull request fixes the issue with `@material-ui/styles`. The `theme` prop is undefined in old version of `DateTimePickerTabs` component.