### PR TITLE
[#907] Spread initialFocusedDate from TimePicker

### DIFF
--- a/lib/src/TimePicker/TimePickerInline.tsx
+++ b/lib/src/TimePicker/TimePickerInline.tsx
@@ -11,7 +11,17 @@ export interface TimePickerInlineProps
     ExtendWrapper<OuterInlineWrapperProps> {}
 
 export const TimePickerInline: React.SFC<TimePickerInlineProps> = props => {
-  const { value, format, onChange, ampm, forwardedRef, seconds, minutesStep, ...other } = props;
+  const {
+    ampm,
+    format,
+    forwardedRef,
+    initialFocusedDate,
+    minutesStep,
+    onChange,
+    seconds,
+    value,
+    ...other
+  } = props;
 
   return (
     <BasePicker mergePreviousDateOnChange autoOk {...props}>

--- a/lib/src/TimePicker/TimePickerModal.tsx
+++ b/lib/src/TimePicker/TimePickerModal.tsx
@@ -11,7 +11,18 @@ export interface TimePickerModalProps
     ExtendWrapper<ModalWrapperProps> {}
 
 export const TimePickerModal: React.SFC<TimePickerModalProps> = props => {
-  const { value, format, autoOk, onChange, ampm, forwardedRef, seconds, minutesStep, ...other } = props;
+  const {
+    ampm,
+    autoOk,
+    format,
+    forwardedRef,
+    initialFocusedDate,
+    minutesStep,
+    onChange,
+    seconds,
+    value,
+    ...other
+  } = props;
 
   return (
     <BasePicker mergePreviousDateOnChange {...props}>
@@ -39,7 +50,13 @@ export const TimePickerModal: React.SFC<TimePickerModalProps> = props => {
           format={pick12hOr24hFormat(utils.time12hFormat, utils.time24hFormat)}
           {...other}
         >
-          <TimePicker date={date} onChange={handleChange} ampm={ampm} seconds={seconds} minutesStep={minutesStep} />
+          <TimePicker
+            date={date}
+            onChange={handleChange}
+            ampm={ampm}
+            seconds={seconds}
+            minutesStep={minutesStep}
+          />
         </ModalWrapper>
       )}
     </BasePicker>


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes #907 <!-- Please refer issue number here, if exists -->

## Description
Spread `initialFocusedDate` to disable warning