### PR TITLE
Fix rollup warning about broken sourcemap

### DIFF
--- a/lib/package-lock.json
+++ b/lib/package-lock.json
@@ -4210,15 +4210,7 @@
       "integrity": "sha512-E2s1b4GVbt8PyG+iaRN6ks8N0Oy2LOJz7SIMUwWWWx7Mr5Z08hKkfpkKQbOtOGqzkFpckDJHjjZ8qfigN2W86A==",
       "dev": true,
       "requires": {
-        "icu4c-data": "^0.61.2"
-      },
-      "dependencies": {
-        "icu4c-data": {
-          "version": "0.62.2",
-          "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.62.2.tgz",
-          "integrity": "sha512-XeGQzD3LAFprTRJ+IJZky7gUEk330neU8oo+xUT7LH08JFLTC1Eh22LiyrKIJPiZKV3w5Nq/cj8QyFWe18VDtw==",
-          "dev": true
-        }
+        "icu4c-data": "^0.60.2"
       }
     },
     "function-bind": {
@@ -4653,6 +4645,12 @@
       "requires": {
         "postcss": "^7.0.5"
       }
+    },
+    "icu4c-data": {
+      "version": "0.60.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.60.2.tgz",
+      "integrity": "sha512-4ScORTYJPIDJRPtAkQWXfKqGk8u1ThOxFWCJ3jkq+rj/MU4cK6isCvhFiEjunivw1/bJ10LqNAaJ9pAK68DEZg==",
+      "dev": true
     },
     "ieee754": {
       "version": "1.1.12",
@@ -10807,7 +10805,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }

--- a/lib/rollup.config.js
+++ b/lib/rollup.config.js
@@ -82,13 +82,10 @@ export default [
       nodeResolve({ extensions }),
       typescriptPlugin({ typescript, tsconfig }),
       babel(babelOptions),
-      {
-        transform(code) {
-          if (code.includes('/** @class */')) {
-            return code.replace(/\/\*\* @class \*\//g, '/*@__PURE__*/');
-          }
-        },
-      },
+      replace({
+        delimiters: ['', ''],
+        values: { '/** @class */': '/*@__PURE__*/' },
+      }),
       sizeSnapshot(),
     ],
   },


### PR DESCRIPTION
By replacing `@class` annotation with `@__PURE__` we broke rollup
internal sourcemap generator.

Found the fix here
https://github.com/ex-machine/rollup-plugin-ts-treeshaking/blob/master/index.js

![image](https://user-images.githubusercontent.com/5635476/52920498-16703a80-331e-11e9-9c76-3c423405f300.png)
