### PR TITLE
Make todayLabel propTypes consistent with TS typings

### DIFF
--- a/lib/src/wrappers/ModalWrapper.tsx
+++ b/lib/src/wrappers/ModalWrapper.tsx
@@ -40,7 +40,7 @@ export default class ModalWrapper extends React.PureComponent<ModalWrapperProps>
     cancelLabel: PropTypes.node,
     clearLabel: PropTypes.node,
     clearable: PropTypes.bool,
-    todayLabel: PropTypes.string,
+    todayLabel: PropTypes.node,
     showTodayButton: PropTypes.bool,
     onOpen: PropTypes.func,
     DialogProps: PropTypes.object,


### PR DESCRIPTION
TS - ```todayLabel?: React.ReactNode;```
propTypes - ```todayLabel: PropTypes.string,```
These two lines are inconsistent and it leads to a warning during render time
```
Warning: Failed prop type: Invalid prop `todayLabel` of type `object` supplied to `ModalWrapper`, expected `string`.
```
If we check similar props like ```okLabel``` etc., then it doesn't make any sense to expect for ```todayLabel``` to be a string.

<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

This PR closes # <!-- Please refer issue number here, if exists -->

## Description
