### PR TITLE
Fix PropTypes warning, if using custom TextField.

### DIFF
--- a/lib/src/_shared/DateTextField.tsx
+++ b/lib/src/_shared/DateTextField.tsx
@@ -103,7 +103,7 @@ export class DateTextField extends React.PureComponent<DateTextFieldProps> {
     keyboardIcon: PropTypes.node,
     disableOpenOnEnter: PropTypes.bool,
     invalidDateMessage: PropTypes.node,
-    TextFieldComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.node]),
+    TextFieldComponent: PropTypes.oneOfType([PropTypes.string, PropTypes.func, PropTypes.node, PropTypes.object]),
     InputAdornmentProps: PropTypes.object,
     KeyboardButtonProps: PropTypes.object,
     adornmentPosition: PropTypes.oneOf(['start', 'end']),


### PR DESCRIPTION
## Description
When using the classical TextField comp. from Material-UI, wrapping it withStyles, results in an object. That is new, but ok.
Therefore extending the PropTypes here, so that warning does not accidentally happen anymore.