### PR TITLE
Toolbar keyboard accessibility

### DIFF
--- a/docs/pages/regression/index.tsx
+++ b/docs/pages/regression/index.tsx
@@ -9,7 +9,7 @@ import RightArrowIcon from '@material-ui/icons/KeyboardArrowRight';
 
 function Regression() {
   const utils = useContext(MuiPickersContext);
-  const [date, changeDate] = useState(new Date('2019-01-01T00:00:00.000Z'));
+  const [date, changeDate] = useState(new Date('2019-01-01T00:00:00.000'));
 
   const sharedProps = {
     value: date,

--- a/lib/src/DatePicker/DatePicker.tsx
+++ b/lib/src/DatePicker/DatePicker.tsx
@@ -165,7 +165,9 @@ export class DatePicker extends React.PureComponent<DatePickerProps> {
       <>
         <PickerToolbar className={clsx({ [classes.toolbarCenter]: this.isYearOnly })}>
           <ToolbarButton
-            variant={this.isYearOnly ? 'h3' : 'subtitle1'}
+            toolbarTextProps={{
+              variant: this.isYearOnly ? 'h3' : 'subtitle1',
+            }}
             onClick={this.isYearOnly ? undefined : this.openYearSelection}
             selected={openView === 'year'}
             label={utils.getYearText(this.date)}
@@ -173,7 +175,9 @@ export class DatePicker extends React.PureComponent<DatePickerProps> {
 
           {!this.isYearOnly && !this.isYearAndMonth && (
             <ToolbarButton
-              variant="h4"
+              toolbarTextProps={{
+                variant: 'h4',
+              }}
               onClick={this.openCalendar}
               selected={openView === 'day'}
               label={utils.getDatePickerHeaderText(this.date)}
@@ -182,7 +186,9 @@ export class DatePicker extends React.PureComponent<DatePickerProps> {
 
           {this.isYearAndMonth && (
             <ToolbarButton
-              variant="h4"
+              toolbarTextProps={{
+                variant: 'h4',
+              }}
               onClick={this.openMonthSelection}
               selected={openView === 'month'}
               label={utils.getMonthText(this.date)}

--- a/lib/src/DateTimePicker/components/DateTimePickerHeader.tsx
+++ b/lib/src/DateTimePicker/components/DateTimePickerHeader.tsx
@@ -40,6 +40,10 @@ export const styles = (theme: Theme) =>
       height: 60,
       minWidth: 110,
       marginRight: 4,
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      justifyContent: 'flex-start',
     },
     timeHeader: {
       height: 65,
@@ -51,6 +55,9 @@ export const styles = (theme: Theme) =>
     ampmSelection: {
       top: 11,
       position: 'relative',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
       marginLeft: 10,
       marginRight: -10,
     },
@@ -128,9 +135,9 @@ export const DateTimePickerHeader: React.SFC<DateTimePickerHeaderProps> = ({
           <div className={classes.ampmSelection}>
             <ToolbarButton
               toolbarTextProps={{
+                className: classes.ampmLabel,
                 variant: 'subtitle1',
               }}
-              className={classes.ampmLabel}
               selected={meridiemMode === 'am'}
               label={utils.getMeridiemText('am')}
               onClick={setMeridiemMode('am')}
@@ -138,9 +145,9 @@ export const DateTimePickerHeader: React.SFC<DateTimePickerHeaderProps> = ({
 
             <ToolbarButton
               toolbarTextProps={{
+                className: classes.ampmLabel,
                 variant: 'subtitle1',
               }}
-              className={classes.ampmLabel}
               selected={meridiemMode === 'pm'}
               label={utils.getMeridiemText('pm')}
               onClick={setMeridiemMode('pm')}

--- a/lib/src/DateTimePicker/components/DateTimePickerHeader.tsx
+++ b/lib/src/DateTimePicker/components/DateTimePickerHeader.tsx
@@ -7,6 +7,7 @@ import createStyles from '@material-ui/core/styles/createStyles';
 import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
 import PickerToolbar from '../../_shared/PickerToolbar';
 import ToolbarButton from '../../_shared/ToolbarButton';
+import ToolbarText from '../../_shared/ToolbarText';
 import { withUtils, WithUtilsProps } from '../../_shared/WithUtils';
 import DateTimePickerView, { DateTimePickerViewType } from '../../constants/DateTimePickerView';
 import { MaterialUiPickersDate } from '../../typings/date';
@@ -82,14 +83,18 @@ export const DateTimePickerHeader: React.SFC<DateTimePickerHeaderProps> = ({
     <PickerToolbar className={clsx(classes.toolbar, { [classes.toolBar24h]: !ampm })}>
       <div className={classes.dateHeader}>
         <ToolbarButton
-          variant="subtitle1"
+          toolbarTextProps={{
+            variant: 'subtitle1',
+          }}
           onClick={() => onOpenViewChange(DateTimePickerView.YEAR)}
           selected={openView === DateTimePickerView.YEAR}
           label={utils.getYearText(date)}
         />
 
         <ToolbarButton
-          variant="h4"
+          toolbarTextProps={{
+            variant: 'h4',
+          }}
           onClick={() => onOpenViewChange(DateTimePickerView.DATE)}
           selected={openView === DateTimePickerView.DATE}
           label={utils.getDateTimePickerHeaderText(date)}
@@ -99,16 +104,20 @@ export const DateTimePickerHeader: React.SFC<DateTimePickerHeaderProps> = ({
       <div className={classes.timeHeader}>
         <div className={classes.hourMinuteLabel}>
           <ToolbarButton
-            variant="h3"
+            toolbarTextProps={{
+              variant: 'h3',
+            }}
             onClick={() => onOpenViewChange(DateTimePickerView.HOUR)}
             selected={openView === DateTimePickerView.HOUR}
             label={utils.getHourText(date, ampm!)}
           />
 
-          <ToolbarButton variant="h3" label=":" selected={false} className={classes.separator} />
+          <ToolbarText variant="h3" label=":" selected={false} className={classes.separator} />
 
           <ToolbarButton
-            variant="h3"
+            toolbarTextProps={{
+              variant: 'h3',
+            }}
             onClick={() => onOpenViewChange(DateTimePickerView.MINUTES)}
             selected={openView === DateTimePickerView.MINUTES}
             label={utils.getMinuteText(date)}
@@ -118,17 +127,21 @@ export const DateTimePickerHeader: React.SFC<DateTimePickerHeaderProps> = ({
         {ampm && (
           <div className={classes.ampmSelection}>
             <ToolbarButton
+              toolbarTextProps={{
+                variant: 'subtitle1',
+              }}
               className={classes.ampmLabel}
               selected={meridiemMode === 'am'}
-              variant="subtitle1"
               label={utils.getMeridiemText('am')}
               onClick={setMeridiemMode('am')}
             />
 
             <ToolbarButton
+              toolbarTextProps={{
+                variant: 'subtitle1',
+              }}
               className={classes.ampmLabel}
               selected={meridiemMode === 'pm'}
-              variant="subtitle1"
               label={utils.getMeridiemText('pm')}
               onClick={setMeridiemMode('pm')}
             />

--- a/lib/src/TimePicker/TimePicker.tsx
+++ b/lib/src/TimePicker/TimePicker.tsx
@@ -208,9 +208,9 @@ export class TimePicker extends React.Component<TimePickerProps> {
             <div className={seconds ? classes.ampmSelectionWithSeconds : classes.ampmSelection}>
               <ToolbarButton
                 toolbarTextProps={{
+                  className: classes.ampmLabel,
                   variant: 'subtitle1',
                 }}
-                className={classes.ampmLabel}
                 selected={meridiemMode === 'am'}
                 label={utils.getMeridiemText('am')}
                 onClick={this.setMeridiemMode('am')}
@@ -218,9 +218,9 @@ export class TimePicker extends React.Component<TimePickerProps> {
 
               <ToolbarButton
                 toolbarTextProps={{
+                  className: classes.ampmLabel,
                   variant: 'subtitle1',
                 }}
-                className={classes.ampmLabel}
                 selected={meridiemMode === 'pm'}
                 label={utils.getMeridiemText('pm')}
                 onClick={this.setMeridiemMode('pm')}

--- a/lib/src/TimePicker/TimePicker.tsx
+++ b/lib/src/TimePicker/TimePicker.tsx
@@ -8,6 +8,7 @@ import createStyles from '@material-ui/core/styles/createStyles';
 import { convertToMeridiem } from '../_helpers/time-utils';
 import PickerToolbar from '../_shared/PickerToolbar';
 import ToolbarButton from '../_shared/ToolbarButton';
+import ToolbarText from '../_shared/ToolbarText';
 import { withUtils, WithUtilsProps } from '../_shared/WithUtils';
 import ClockType from '../constants/ClockType';
 import { MeridiemMode } from '../DateTimePicker/components/DateTimePickerHeader';
@@ -162,16 +163,21 @@ export class TimePicker extends React.Component<TimePickerProps> {
         >
           <div className={hourMinuteClassName}>
             <ToolbarButton
-              variant="h2"
+              toolbarTextProps={{
+                variant: 'h2',
+              }}
               onClick={this.openHourView}
               selected={openView === ClockType.HOURS}
               label={utils.getHourText(date, Boolean(ampm))}
+              size="large"
             />
 
-            <ToolbarButton variant="h2" label=":" selected={false} className={classes.separator} />
+            <ToolbarText variant="h2" label=":" selected={false} className={classes.separator} />
 
             <ToolbarButton
-              variant="h2"
+              toolbarTextProps={{
+                variant: 'h2',
+              }}
               onClick={this.openMinutesView}
               selected={openView === ClockType.MINUTES}
               label={utils.getMinuteText(date)}
@@ -179,7 +185,7 @@ export class TimePicker extends React.Component<TimePickerProps> {
 
             {seconds && (
               <React.Fragment>
-                <ToolbarButton
+                <ToolbarText
                   variant="h2"
                   label=":"
                   selected={false}
@@ -187,7 +193,9 @@ export class TimePicker extends React.Component<TimePickerProps> {
                 />
 
                 <ToolbarButton
-                  variant="h2"
+                  toolbarTextProps={{
+                    variant: 'h2',
+                  }}
                   onClick={this.openSecondsView}
                   selected={openView === ClockType.SECONDS}
                   label={utils.getSecondText(date)}
@@ -199,17 +207,21 @@ export class TimePicker extends React.Component<TimePickerProps> {
           {ampm && (
             <div className={seconds ? classes.ampmSelectionWithSeconds : classes.ampmSelection}>
               <ToolbarButton
+                toolbarTextProps={{
+                  variant: 'subtitle1',
+                }}
                 className={classes.ampmLabel}
                 selected={meridiemMode === 'am'}
-                variant="subtitle1"
                 label={utils.getMeridiemText('am')}
                 onClick={this.setMeridiemMode('am')}
               />
 
               <ToolbarButton
+                toolbarTextProps={{
+                  variant: 'subtitle1',
+                }}
                 className={classes.ampmLabel}
                 selected={meridiemMode === 'pm'}
-                variant="subtitle1"
                 label={utils.getMeridiemText('pm')}
                 onClick={this.setMeridiemMode('pm')}
               />
@@ -247,10 +259,16 @@ export const styles = () =>
       cursor: 'default',
     },
     ampmSelection: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
       marginLeft: 20,
       marginRight: -20,
     },
     ampmSelectionWithSeconds: {
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'center',
       marginLeft: 15,
       marginRight: 10,
     },

--- a/lib/src/__tests__/_shared/ToolbarText.test.tsx
+++ b/lib/src/__tests__/_shared/ToolbarText.test.tsx
@@ -1,0 +1,16 @@
+import { ShallowWrapper } from 'enzyme';
+import * as React from 'react';
+import ToolbarText, { ToolbarTextProps } from '../../_shared/ToolbarText';
+import { shallow } from '../test-utils';
+
+describe('Toolbar Text', () => {
+  let component: ShallowWrapper<ToolbarTextProps>;
+
+  beforeEach(() => {
+    component = shallow(<ToolbarText selected={true} label="hello" />);
+  });
+
+  it('Should render', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/lib/src/__tests__/e2e/DatePicker.test.tsx
+++ b/lib/src/__tests__/e2e/DatePicker.test.tsx
@@ -12,7 +12,7 @@ describe('e2e - DatePicker', () => {
     component = mount(
       <DatePicker
         animateYearScrolling={false}
-        date={utilsToUse.date('2018-01-01T00:00:00.000Z')}
+        date={utilsToUse.date('2018-01-01T00:00:00.000')}
         onChange={onChangeMock}
       />
     );

--- a/lib/src/__tests__/e2e/DateTimePicker.test.tsx
+++ b/lib/src/__tests__/e2e/DateTimePicker.test.tsx
@@ -52,7 +52,7 @@ describe('e2e - DateTimePicker', () => {
   it('Should render minutes view', () => {
     component
       .find('ToolbarButton')
-      .at(4)
+      .at(3)
       .simulate('click');
     expect(component.find('TimePickerView').props().type).toBe('minutes');
   });
@@ -60,7 +60,7 @@ describe('e2e - DateTimePicker', () => {
   it('Should change meridiem', () => {
     component
       .find('ToolbarButton')
-      .at(6)
+      .at(4)
       .simulate('click');
 
     if (process.env.UTILS === 'moment') {

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -9,7 +9,7 @@ import { ExtendMui } from '../typings/extendMui';
 import ToolbarText from './ToolbarText';
 
 export interface ToolbarButtonProps extends ExtendMui<ButtonProps>, WithStyles<typeof styles> {
-  toolbarTextProps: ExtendMui<TypographyProps>;
+  toolbarTextProps?: ExtendMui<TypographyProps>;
   selected: boolean;
   label: string;
 }

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -45,6 +45,7 @@ export const styles = createStyles({
   toolbarBtn: {
     padding: 0,
     minWidth: '16px',
+    textTransform: 'none',
   },
 });
 

--- a/lib/src/_shared/ToolbarButton.tsx
+++ b/lib/src/_shared/ToolbarButton.tsx
@@ -1,32 +1,33 @@
-import { Theme } from '@material-ui/core';
-import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
-import Typography, { TypographyProps } from '@material-ui/core/Typography';
+import { createStyles, withStyles, WithStyles } from '@material-ui/core';
+import Button, { ButtonProps } from '@material-ui/core/Button';
+import { TypographyProps } from '@material-ui/core/Typography';
 import clsx from 'clsx';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
-import { ExtendMui } from '../typings/extendMui';
 
-export interface ToolbarButtonProps extends ExtendMui<TypographyProps>, WithStyles<typeof styles> {
+import { ExtendMui } from '../typings/extendMui';
+import ToolbarText from './ToolbarText';
+
+export interface ToolbarButtonProps extends ExtendMui<ButtonProps>, WithStyles<typeof styles> {
+  toolbarTextProps: ExtendMui<TypographyProps>;
   selected: boolean;
   label: string;
 }
 
-const ToolbarButton: React.SFC<ToolbarButtonProps> = ({
+const ToolbarButton: React.FunctionComponent<ToolbarButtonProps> = ({
   classes,
-  selected,
-  label,
   className = null,
+  label,
+  selected,
+  toolbarTextProps,
   ...other
-}) => (
-  <Typography
-    className={clsx(classes.toolbarBtn, className, {
-      [classes.toolbarBtnSelected]: selected,
-    })}
-    {...other}
-  >
-    {label}
-  </Typography>
-);
+}) => {
+  return (
+    <Button className={clsx(classes.toolbarBtn, className)} {...other}>
+      <ToolbarText {...toolbarTextProps} label={label} selected={selected} />
+    </Button>
+  );
+};
 
 (ToolbarButton as any).propTypes = {
   selected: PropTypes.bool.isRequired,
@@ -40,13 +41,10 @@ ToolbarButton.defaultProps = {
   className: '',
 };
 
-export const styles = (theme: Theme) => ({
+export const styles = createStyles({
   toolbarBtn: {
-    cursor: 'pointer',
-    color: 'rgba(255, 255, 255, 0.54)',
-  },
-  toolbarBtnSelected: {
-    color: theme.palette.common.white,
+    padding: 0,
+    minWidth: '16px',
   },
 });
 

--- a/lib/src/_shared/ToolbarText.tsx
+++ b/lib/src/_shared/ToolbarText.tsx
@@ -1,0 +1,52 @@
+import { Theme } from '@material-ui/core';
+import withStyles, { WithStyles } from '@material-ui/core/styles/withStyles';
+import Typography, { TypographyProps } from '@material-ui/core/Typography';
+import clsx from 'clsx';
+import * as PropTypes from 'prop-types';
+import * as React from 'react';
+import { ExtendMui } from '../typings/extendMui';
+
+export interface ToolbarTextProps extends ExtendMui<TypographyProps>, WithStyles<typeof styles> {
+  selected: boolean;
+  label: string;
+}
+
+const ToolbarText: React.FunctionComponent<ToolbarTextProps> = ({
+  classes,
+  selected,
+  label,
+  className = null,
+  ...other
+}) => (
+  <Typography
+    className={clsx(classes.toolbarTxt, className, {
+      [classes.toolbarBtnSelected]: selected,
+    })}
+    {...other}
+  >
+    {label}
+  </Typography>
+);
+
+(ToolbarText as any).propTypes = {
+  selected: PropTypes.bool.isRequired,
+  label: PropTypes.string.isRequired,
+  classes: PropTypes.any.isRequired,
+  className: PropTypes.string,
+  innerRef: PropTypes.any,
+};
+
+ToolbarText.defaultProps = {
+  className: '',
+};
+
+export const styles = (theme: Theme) => ({
+  toolbarTxt: {
+    color: 'rgba(255, 255, 255, 0.54)',
+  },
+  toolbarBtnSelected: {
+    color: theme.palette.common.white,
+  },
+});
+
+export default withStyles(styles, { name: 'MuiPickersToolbarText' })(ToolbarText);


### PR DESCRIPTION
<!-- Thanks so much for your time taking to contribute, your work is appreciated! ❤️ -->

## Description
This PR converts the `ToolbarButton` component to actually use the Material UI buttons. This makes the picker toolbars keyboard accessible, so users can tab through the different selection options.

## Notes

The dimensions of some of the toolbar buttons prevent the focus ripple from covering all the text like below. The focus ripple dimensions are not configurable (see the MUI code [here](https://github.com/mui-org/material-ui/blob/e1b5facbd44e5b51ffa4667770d119b8a44491d2/packages/material-ui/src/ButtonBase/TouchRipple.js#L157)). To fix this, changes to MUI would be needed.
<img width="205" alt="image" src="https://user-images.githubusercontent.com/10750197/55666156-9a677e80-5807-11e9-9dcf-04925f8b5769.png">

Cypress tests could not be easily added to test the tabbing functionality due to this open issue:
https://github.com/cypress-io/cypress/issues/299